### PR TITLE
Small text fixes

### DIFF
--- a/templates/home.tmpl
+++ b/templates/home.tmpl
@@ -54,8 +54,7 @@
 			<p class="large">
 				Its based on open source projects such as <a href="https://git-scm.com/">git</a>, <a
 				href="https://git-annex.branchable.com/">git-annex</a> and <a href="https://github.com/gogits/gogs">gogs</a>.
-				Everything is freely availible as source.
-				code.
+				Everything is freely availible as source code.
 				You can even set it up in your lab!
 			</p>
 		</div>

--- a/templates/repo/create.tmpl
+++ b/templates/repo/create.tmpl
@@ -57,7 +57,7 @@
 
 					<div class="ui divider"></div>
 
-					<div class="ui inline field" data-tooltip="In case of data repositories you probably dont need this">
+					<div class="ui inline field" data-tooltip="In the case of data repositories you probably don't need this">
 						<label>.gitignore</label>
 						<a target="_blank"
 							 href="https://git-scm.com/docs/gitignore"><span


### PR DESCRIPTION
Removed an extra period on the home page and fixed the new repository .gitignore tooltip text.
