### PR TITLE
Remove support for hiding repositories based on name

### DIFF
--- a/cmd/serv.go
+++ b/cmd/serv.go
@@ -38,7 +38,7 @@ var Serv = cli.Command{
 }
 
 func fail(userMessage, logMessage string, args ...interface{}) {
-	fmt.Fprintln(os.Stderr, "Gin:", userMessage)
+	fmt.Fprintln(os.Stderr, "GIN:", userMessage)
 
 	if len(logMessage) > 0 {
 		if !setting.ProdMode {
@@ -134,7 +134,7 @@ func runServ(c *cli.Context) error {
 	setup(c, "serv.log", true)
 
 	if setting.SSH.Disabled {
-		println("Gins: SSH has been disabled")
+		println("GIN: SSH has been disabled")
 		return nil
 	}
 
@@ -145,7 +145,7 @@ func runServ(c *cli.Context) error {
 	sshCmd := strings.Replace(os.Getenv("SSH_ORIGINAL_COMMAND"), "'", "", -1)
 	log.Info("SSH commadn:%s", sshCmd)
 	if len(sshCmd) == 0 {
-		println("Hi there, You've successfully authenticated, but Gin does not provide shell access.")
+		println("Hi there, You've successfully authenticated, but GIN does not provide shell access.")
 		return nil
 	}
 

--- a/gogs.go
+++ b/gogs.go
@@ -24,7 +24,7 @@ func init() {
 
 func main() {
 	app := cli.NewApp()
-	app.Name = "Gin"
+	app.Name = "GIN"
 	app.Usage = "Modern Research Data Management for Neuroscience"
 	app.Version = APP_VER
 	app.Commands = []cli.Command{

--- a/models/models_gin.go
+++ b/models/models_gin.go
@@ -50,16 +50,16 @@ func annexUninit(path string) {
 		}
 
 		if err := os.Chmod(path, mode); err != nil {
-			log.Error(1, "failed to change permissions on '%s': %v", path, err)
+			log.Error(3, "failed to change permissions on '%s': %v", path, err)
 		}
 		return nil
 	}
 
 	log.Trace("Uninit annex at '%s'", path)
 	if msg, err := gannex.Uninit(path); err != nil {
-		log.Error(1, "uninit failed: %v (%s)", err, msg)
+		log.Error(3, "uninit failed: %v (%s)", err, msg)
 		if werr := filepath.Walk(path, walker); werr != nil {
-			log.Error(1, "file permission change failed: %v", werr)
+			log.Error(3, "file permission change failed: %v", werr)
 		}
 	}
 }

--- a/routes/user/user_gin.go
+++ b/routes/user/user_gin.go
@@ -10,7 +10,5 @@ import (
 func excludeFromFeed(act *models.Action) bool {
 	return strings.Contains(act.RefName, "synced/git-annex") ||
 		strings.Contains(act.RefName, "synced/master") ||
-		strings.Contains(act.RefName, "git-annex") ||
-		strings.Contains(act.RepoName, "hideme") ||
-		strings.Contains(act.RepoName, "unlisted")
+		strings.Contains(act.RefName, "git-annex")
 }

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -5,7 +5,7 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 	{{if not .PageIsAdmin}}
 		<meta name="author" content="{{if .Repository}}{{.Owner.Name}}{{else}}G-Node{{end}}"/>
-		<meta name="description" content="{{if .Repository}}{{.Repository.Name}}{{if .Repository.Description}} - {{.Repository.Description}}{{end}}{{else}}Gin is a data repository for science{{end}}"/>
+		<meta name="description" content="{{if .Repository}}{{.Repository.Name}}{{if .Repository.Description}} - {{.Repository.Description}}{{end}}{{else}}GIN is a data repository for science{{end}}"/>
 		<meta name="keywords" content="gin, data, sharing, science git">
 	{{end}}
 	<meta name="referrer" content="no-referrer" />

--- a/templates/inject/head.tmpl
+++ b/templates/inject/head.tmpl
@@ -1,14 +1,13 @@
 <!-- Custom CSS overrides -->
 <link rel="stylesheet" href="/css/custom.css">
 
-
-	{{if or .PageIsExploreRepositories (or .PageIsHome .PageIsWiki) }}
-		<meta name="robots" content="nofollow"/>
-	{{else if .PageIsViewFiles }}
-		<meta name="robots" content="noindex,nofollow"/>
-	{{else}}
-		<meta name="robots" content="noindex, nofollow"/>
-	{{end}}
+{{if or .PageIsExploreRepositories (or .PageIsHome .PageIsWiki) }}
+	<meta name="robots" content="nofollow"/>
+{{else if .PageIsViewFiles }}
+	<meta name="robots" content="noindex,nofollow"/>
+{{else}}
+	<meta name="robots" content="noindex,nofollow"/>
+{{end}}
 
 <!-- Front page cursive font -->
 <link href='https://fonts.googleapis.com/css?family=Kaushan+Script' rel='stylesheet' type='text/css'>
@@ -16,7 +15,7 @@
 <!-- twitterish -->
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@gnode" />
-<meta name="twitter:title" content=" GIN" />
+<meta name="twitter:title" content="GIN" />
 <meta name="twitter:description" content="Modern Research Data Management for Neuroscience"/>
 <meta name="twitter:image" content="https://web.gin.g-node.org/img/favicon.png" />
 


### PR DESCRIPTION
At some point we introduced the option of adding "hideme" or "unlisted" to repository names in order to hide them from the dashboard and the explore page.  Repositories can now be hidden from Explore using the "Unlisted" option.

Secondary commit for more useful error message reporting when annex uninit fails.  With skip 3, it displays the name of the calling function for `annexUninit()`.