### PR TITLE
Live banner from file

### DIFF
--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -330,6 +330,8 @@ func Contexter() macaron.Handler {
 
 		c.Data["auto_init"] = true
 
+		readNotice(c) // GIN mod: Add notice if notice file exists
+
 		ctx.Map(c)
 	}
 }

--- a/pkg/context/context_gin.go
+++ b/pkg/context/context_gin.go
@@ -28,6 +28,7 @@ func readNotice(c *Context) {
 		log.Error(2, "Failed to open notice file %s: %v", fileloc, err)
 		return
 	}
+	defer fp.Close()
 
 	finfo, err := fp.Stat()
 	if err != nil {

--- a/pkg/context/context_gin.go
+++ b/pkg/context/context_gin.go
@@ -1,0 +1,53 @@
+package context
+
+import (
+	"os"
+	"path"
+	"strings"
+
+	"github.com/G-Node/gogs/pkg/setting"
+	"github.com/Unknwon/com"
+	log "gopkg.in/clog.v1"
+)
+
+// readNotice checks if a notice file exists and loads the message to display
+// on all pages.
+func readNotice(c *Context) {
+
+	fileloc := path.Join(setting.CustomPath, "notice")
+	var maxlen int64 = 1024
+
+	if !com.IsExist(fileloc) {
+		return
+	}
+	log.Trace("Found notice file")
+	fp, err := os.Open(fileloc)
+	if err != nil {
+		log.Error(2, "Failed to open notice file %s: %v", fileloc, err)
+		return
+	}
+
+	finfo, err := fp.Stat()
+	if err != nil {
+		log.Error(2, "Failed to stat notice file %s: %v", fileloc, err)
+		return
+	}
+
+	if finfo.Size() > maxlen { // Refuse to print very long messages
+		log.Error(2, "Notice file %s size too large [%d > %d]: refusing to render", fileloc, finfo.Size(), maxlen)
+		return
+	}
+
+	buf := make([]byte, maxlen)
+	n, err := fp.Read(buf)
+	if err != nil {
+		log.Error(2, "Failed to read notice file: %v", err)
+		return
+	}
+	buf = buf[:n]
+
+	noticetext := strings.SplitN(string(buf), "\n", 2)
+	c.Data["HasNotice"] = true
+	c.Data["NoticeTitle"] = noticetext[0]
+	c.Data["NoticeMessage"] = noticetext[1]
+}

--- a/pkg/context/context_gin.go
+++ b/pkg/context/context_gin.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/G-Node/gogs/pkg/setting"
+	"github.com/G-Node/gogs/pkg/tool"
 	"github.com/Unknwon/com"
 	log "gopkg.in/clog.v1"
 )
@@ -20,6 +21,7 @@ func readNotice(c *Context) {
 	if !com.IsExist(fileloc) {
 		return
 	}
+
 	log.Trace("Found notice file")
 	fp, err := os.Open(fileloc)
 	if err != nil {
@@ -45,6 +47,11 @@ func readNotice(c *Context) {
 		return
 	}
 	buf = buf[:n]
+
+	if !tool.IsTextFile(buf) {
+		log.Error(2, "Notice file %s does not appear to be a text file: aborting", fileloc)
+		return
+	}
 
 	noticetext := strings.SplitN(string(buf), "\n", 2)
 	c.Data["HasNotice"] = true

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -199,7 +199,7 @@
 					<div class="header">
 						{{.NoticeTitle}}
 					</div>
-					<p>{{.NoticeMessage}}</p>
+					<p>{{.NoticeMessage | Str2HTML}}</p>
 				</div>
 			</div>
 		{{end}}

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -87,6 +87,8 @@
 				<div class="ui container">
 					<div class="ui grid">
 						<div class="column">
+
+
 							<div class="ui top secondary menu">
 								<a class="item brand" href="{{AppSubURL}}/">
 									<img class="ui mini image" src="{{AppSubURL}}/img/favicon.png">
@@ -189,6 +191,17 @@
 					</div><!-- end grid -->
 				</div><!-- end container -->
 			</div><!-- end bar -->
+		{{end}}
+
+		{{if .HasNotice}}
+			<div class="ui container grid warning message">
+				<div class="content">
+					<div class="header">
+						{{.NoticeTitle}}
+					</div>
+					<p>{{.NoticeMessage}}</p>
+				</div>
+			</div>
 		{{end}}
 {{/*
 	</div>


### PR DESCRIPTION
New function looks for a file called `notice` in the custom directory and renders the contents as a banner notice on every page.  Meant to be used to display service notices without requiring a server restart.

The first line in the file is interpreted as the title and everything below it is the message.  Message text can include HTML code (for linking or text styling.

The file must be 1024 bytes or smaller and must be identified as a text file (MIME type).

Screenshot below shows example from local test:
![image](https://user-images.githubusercontent.com/2369197/58266645-64b03200-7d82-11e9-82e3-84c821636259.png)
