### PR TITLE
Fix/web upload annex

### DIFF
--- a/models/models_gin.go
+++ b/models/models_gin.go
@@ -137,5 +137,11 @@ func annexSync(path string) error {
 		log.Error(2, "Annex sync failed: %v (%s)", err, msg)
 		return fmt.Errorf("git annex sync --content [%s]", path)
 	}
+
+	// run twice; required if remote annex is not initialised
+	if msg, err := gannex.ASync(path, "--content"); err != nil {
+		log.Error(2, "Annex sync failed: %v (%s)", err, msg)
+		return fmt.Errorf("git annex sync --content [%s]", path)
+	}
 	return nil
 }

--- a/models/models_gin.go
+++ b/models/models_gin.go
@@ -103,18 +103,24 @@ func annexSetup(path string) {
 
 	// Initialise annex in case it's a new repository
 	if msg, err := gannex.Init(path, "--version=7"); err != nil {
-		log.Error(1, "Annex init failed: %v (%s)", err, msg)
+		log.Error(2, "Annex init failed: %v (%s)", err, msg)
+		return
+	}
+
+	// Upgrade to v7 in case the directory was here before and wasn't cleaned up properly
+	if msg, err := gannex.Upgrade(path); err != nil {
+		log.Error(2, "Annex upgrade failed: %v (%s)", err, msg)
 		return
 	}
 
 	// Enable addunlocked for annex v7
 	if msg, err := gannex.SetAddUnlocked(path); err != nil {
-		log.Error(1, "Failed to set 'addunlocked' annex option: %v (%s)", err, msg)
+		log.Error(2, "Failed to set 'addunlocked' annex option: %v (%s)", err, msg)
 	}
 
 	// Set MD5 as default backend
 	if msg, err := gannex.MD5(path); err != nil {
-		log.Error(1, "Failed to set default backend to 'MD5': %v (%s)", err, msg)
+		log.Error(2, "Failed to set default backend to 'MD5': %v (%s)", err, msg)
 	}
 
 	// Set size filter in config
@@ -128,7 +134,7 @@ func annexSync(path string) error {
 	if msg, err := gannex.ASync(path, "--content"); err != nil {
 		// TODO: This will also DOWNLOAD content, which is unnecessary for a simple upload
 		// TODO: Use gin-cli upload function instead
-		log.Error(1, "Annex sync failed: %v (%s)", err, msg)
+		log.Error(2, "Annex sync failed: %v (%s)", err, msg)
 		return fmt.Errorf("git annex sync --content [%s]", path)
 	}
 	return nil

--- a/models/repo_editor.go
+++ b/models/repo_editor.go
@@ -518,7 +518,7 @@ func (repo *Repository) UploadRepoFiles(doer *User, opts UploadRepoFileOptions) 
 	}
 
 	if err := annexSync(localPath); err != nil { // Run full annex sync
-		return err
+		return fmt.Errorf("annex sync %s: %v", localPath, err)
 	}
 	annexUninit(localPath) // Uninitialise annex to prepare for deletion
 	StartIndexing(*repo)   // Index the new data

--- a/vendor/github.com/G-Node/go-annex/add.go
+++ b/vendor/github.com/G-Node/go-annex/add.go
@@ -19,6 +19,11 @@ func Init(dir string, args ...string) (string, error) {
 	return cmd.AddArguments(args...).RunInDir(dir)
 }
 
+func Upgrade(dir string) (string, error) {
+	cmd := git.NewACommand("upgrade")
+	return cmd.RunInDir(dir)
+}
+
 func Uninit(dir string, args ...string) (string, error) {
 	cmd := git.NewACommand("uninit")
 	return cmd.AddArguments(args...).RunInDir(dir)


### PR DESCRIPTION
On new repositories, the first sync doesn't upload the data and a second
one is required to initialise the remote annex and then upload.  This
should be fixed in a better way (e.g., by initialising the remote
explicitly) but for now we need this workaround.

We had this previously and it got removed in the rebase.  This was causing failures to upload files through the web for new repositories.
