### PR TITLE
DOI: New request data

### DIFF
--- a/routes/doi.go
+++ b/routes/doi.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/url"
 
@@ -17,9 +18,19 @@ func RequestDOI(c *context.Context) {
 		return
 	}
 
-	repo := c.Repo.Repository.FullName()
 	username := c.User.Name
-	verification, err := libgin.EncryptURLString([]byte(setting.DOI.Key), repo+username)
+	realname := c.User.FullName
+	repo := c.Repo.Repository.FullName()
+	email := c.User.Email
+
+	data := map[string]string{
+		"username":   username,
+		"realname":   realname,
+		"repository": repo,
+		"email":      email,
+	}
+	dataj, _ := json.Marshal(data)
+	regrequest, err := libgin.EncryptURLString([]byte(setting.DOI.Key), string(dataj))
 	if err != nil {
 		log.Error(2, "Could not encrypt secret key: %s", err)
 		c.Status(http.StatusInternalServerError)
@@ -31,9 +42,7 @@ func RequestDOI(c *context.Context) {
 	}
 
 	params := url.Values{}
-	params.Add("repo", repo)
-	params.Add("user", username)
-	params.Add("verification", verification)
+	params.Add("regrequest", regrequest)
 	doiurl.RawQuery = params.Encode()
 	target, _ := url.PathUnescape(doiurl.String())
 	log.Trace(target)

--- a/routes/doi.go
+++ b/routes/doi.go
@@ -29,6 +29,8 @@ func RequestDOI(c *context.Context) {
 		"repository": repo,
 		"email":      email,
 	}
+
+	log.Trace("Encrypting data for DOI: %+v", data)
 	dataj, _ := json.Marshal(data)
 	regrequest, err := libgin.EncryptURLString([]byte(setting.DOI.Key), string(dataj))
 	if err != nil {

--- a/routes/doi.go
+++ b/routes/doi.go
@@ -23,11 +23,11 @@ func RequestDOI(c *context.Context) {
 	repo := c.Repo.Repository.FullName()
 	email := c.User.Email
 
-	data := map[string]string{
-		"username":   username,
-		"realname":   realname,
-		"repository": repo,
-		"email":      email,
+	data := libgin.DOIRequestData{
+		Username:   username,
+		Realname:   realname,
+		Repository: repo,
+		Email:      email,
 	}
 
 	log.Trace("Encrypting data for DOI: %+v", data)

--- a/vendor/github.com/G-Node/libgin/libgin/doi.go
+++ b/vendor/github.com/G-Node/libgin/libgin/doi.go
@@ -34,6 +34,15 @@ func RepoPathToUUID(URI string) string {
 	return hex.EncodeToString(currMd5[:])
 }
 
+// DOIRequestData is used to transmit data from GIN to DOI when a registration
+// request is triggered.
+type DOIRequestData struct {
+	Username   string
+	Realname   string
+	Repository string
+	Email      string
+}
+
 // DOIRegInfo holds all the metadata and information necessary for a DOI registration request.
 type DOIRegInfo struct {
 	Missing      []string


### PR DESCRIPTION
New form of request data transmission to DOI:
Data is marshalled to a JSON object and encrypted to be sent via the query string.  The DOI service decrypts the data, which now includes the user's full name (if set) and email address.

See G-Node/libgin#3 and G-Node/gin-doi#31.