### PR TITLE
Change reference 'name' field to 'citation' in datacite

### DIFF
--- a/conf/datacite/datacite.yml
+++ b/conf/datacite/datacite.yml
@@ -56,20 +56,24 @@ funding:
 # Please provide digital identifier (e.g., DOI) if possible.
 # Add a prefix to the ID, separated by a colon, to indicate the source.
 # Supported sources are: DOI, arXiv, PMID
+# In the citation field, please provide the full reference, including title, authors, journal etc.
 references:
   -
     id: "doi:10.xxx/zzzz"
     reftype: "IsSupplementTo"
-    name: "PublicationName1"
+    citation: "Citation1"
   -
     id: "arxiv:mmmm.nnnn"
     reftype: "IsSupplementTo"
-    name: "PublicationName2"
+    citation: "Citation2"
   -
     id: "pmid:nnnnnnnn"
     reftype: "IsReferencedBy"
-    name: "PublicationName3"
+    citation: "Citation3"
 
 
 # Resource type. Default is Dataset, other possible values are Software, DataPaper, Image, Text.
 resourcetype: Dataset
+
+# Do not edit or remove the following line
+templateversion: 1.2

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/G-Node/git-module v0.8.4-gnode
-	github.com/G-Node/libgin v0.3.1
+	github.com/G-Node/libgin v0.3.2
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/denisenkom/go-mssqldb v0.0.0-20191001013358-cfbb681360f0
 	github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0
@@ -70,5 +70,3 @@ require (
 	xorm.io/core v0.7.2
 	xorm.io/xorm v0.8.0
 )
-
-// +heroku goVersion go1.13beta1

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/G-Node/git-module v0.8.4-gnode h1:BNtyp/2J+zisHObMqrxazJ2fb2ASPu30uN8
 github.com/G-Node/git-module v0.8.4-gnode/go.mod h1:TdKR+8dChXtB7Hw3xS4Bfn5QQenPnihuoWx/vnSnb1k=
 github.com/G-Node/libgin v0.0.0-20191216094436-47f8aadc0067/go.mod h1:2yLXQnNbwjH8mslxnzU8Kb+d7c2Zqo8DIgR6Pgp7lCg=
 github.com/G-Node/libgin v0.3.0/go.mod h1:VjulCBq7k/kgf4Eabk2f4w9SDNowWhLnK+yZvy5Nppk=
-github.com/G-Node/libgin v0.3.1 h1:R6yDRkJ0DlUgD7Y4vZrdKX0DzaTDMYfSbWRm+hw3k3I=
-github.com/G-Node/libgin v0.3.1/go.mod h1:2znNE//YIHBGGXeYCHf0q5+IiOalliAbpG3nGZq9hKY=
+github.com/G-Node/libgin v0.3.2 h1:pbOIm+paF4VqfrTvSu4sPXmo2j5XSOnfxf137uzAHIs=
+github.com/G-Node/libgin v0.3.2/go.mod h1:/2l42QsLZTneVp2LjPoPOWhVjvfbO26atvcbvWA+axI=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -21,6 +21,7 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
@@ -36,6 +37,7 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSY
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cupcake/rdb v0.0.0-20161107195141-43ba34106c76/go.mod h1:vYwsqCOLxGiisLwp9rITslkFNpZD5rz43tf41QFkTWY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denisenkom/go-mssqldb v0.0.0-20190707035753-2be1aa521ff4/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=
 github.com/denisenkom/go-mssqldb v0.0.0-20191001013358-cfbb681360f0 h1:epsH3lb7KVbXHYk7LYGN5EiE0MxcevHU85CKITJ0wUY=
@@ -77,6 +79,7 @@ github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-xorm/builder v0.3.4 h1:FxkeGB4Cggdw3tPwutLCpfjng2jugfkg6LDMrd/KsoY=
 github.com/go-xorm/builder v0.3.4/go.mod h1:KxkQkNN1DpPKTedxXyTQcmH+rXfvk4LZ9SOOBoZBAxw=
+github.com/go-xorm/sqlfiddle v0.0.0-20180821085327-62ce714f951a h1:9wScpmSP5A3Bk8V3XHWUcJmYTh+ZnlHVyc+A4oZYS3Y=
 github.com/go-xorm/sqlfiddle v0.0.0-20180821085327-62ce714f951a/go.mod h1:56xuuqnHyryaerycW3BfssRdxQstACi0Epw/yC5E2xM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -103,6 +106,7 @@ github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8l
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
@@ -120,6 +124,7 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/issue9/assert v1.3.1 h1:L8pRpbnzMIPFJqrMKR/oG03uWrtVeZyYBpI2U2Jx1JE=
 github.com/issue9/assert v1.3.1/go.mod h1:9Ger+iz8X7r1zMYYwEhh++2wMGWcNN2oVI+zIQXxcio=
 github.com/issue9/identicon v1.0.1 h1:pCDfjMDM6xWK0Chxo8Lif+ST/nOEtmXgMITgV1YA9Og=
 github.com/issue9/identicon v1.0.1/go.mod h1:UKNVkUFI68RPz/RlLhsAr1aX6bBSaYEWRHVfdjrMUmk=
@@ -140,8 +145,10 @@ github.com/klauspost/cpuid v1.2.1 h1:vJi+O/nMdFt0vqm8NZBI6wzALWdA2X+egi0ogNyrC/w
 github.com/klauspost/cpuid v1.2.1/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
@@ -189,6 +196,7 @@ github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUr
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.2.0 h1:/A3+Jn+cagqayeR3iHs/L62m5ue7710D35zl1zJ1kok=
 github.com/pquerna/otp v1.2.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
@@ -216,6 +224,7 @@ github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNue
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/saintfish/chardet v0.0.0-20120816061221-3af4cd4741ca h1:NugYot0LIVPxTvN8n+Kvkn6TrbMyxQiuvKdEwFdR9vI=
 github.com/saintfish/chardet v0.0.0-20120816061221-3af4cd4741ca/go.mod h1:uugorj2VCxiV1x+LzaIdVa9b4S4qGAcH6cbhh4qVxOU=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
@@ -243,6 +252,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/unknwon/cae v1.0.0 h1:i39lOFaBXZxhGjQOy/RNbi8uzettCs6OQxpR0xXohGU=
@@ -256,6 +266,7 @@ github.com/unknwon/paginater v0.0.0-20170405233947-45e5d631308e h1:Qf3QQl/zmEbWD
 github.com/unknwon/paginater v0.0.0-20170405233947-45e5d631308e/go.mod h1:TBwoao3Q4Eb/cp+dHbXDfRTrZSsj/k7kLr2j1oWRWC0=
 github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/ziutek/mymysql v1.5.4 h1:GB0qdRGsTwQSBVYuVShFBKaXSnSnYYC2d9knnE1LHFs=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -339,6 +350,7 @@ gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d/go.mod h1:cuepJuh7vyXfUy
 gopkg.in/bufio.v1 v1.0.0-20140618132640-567b2bfa514e h1:wGA78yza6bu/mWcc4QfBuIEHEtc06xdiU0X8sY36yUU=
 gopkg.in/bufio.v1 v1.0.0-20140618132640-567b2bfa514e/go.mod h1:xsQCaysVCudhrYTfzYWe577fCe7Ceci+6qjO2Rdc0Z4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/clog.v1 v1.2.0 h1:BHfwHRNQy497iBNsRBassPixSAxRbn2z5KVkdBFbwxc=
 gopkg.in/clog.v1 v1.2.0/go.mod h1:L6fgdpdhFgKX4eGuDvt+N6X2GwZE160NRrIHzvaF8ZM=

--- a/internal/bindata/bindata.go
+++ b/internal/bindata/bindata.go
@@ -316,12 +316,12 @@ func confAppIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/app.ini", size: 17775, mode: os.FileMode(432), modTime: time.Unix(1576589367, 0)}
+	info := bindataFileInfo{name: "conf/app.ini", size: 17775, mode: os.FileMode(432), modTime: time.Unix(1577104923, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
-var _confDataciteDataciteYml = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x9c\x55\x4f\x6f\xdb\xb8\x13\xbd\xeb\x53\x3c\x38\x97\x5f\x01\x45\x96\xf3\xa7\xed\x4f\xb7\xd6\x4a\x0a\x03\x6d\x13\x24\x29\xd0\x2b\x25\x8e\xac\x41\x28\x52\x4b\x52\xae\x1d\xec\x87\x5f\x90\x92\x13\x65\x17\x9b\x02\xeb\x9b\x48\xce\x9b\x99\x37\x6f\x9e\x4f\xf0\x8d\xbc\x90\xc2\x0b\x34\xc6\xa2\xbc\xd9\xc0\xd2\x96\x9d\xb7\xc2\xb3\xd1\x10\x75\x6d\xac\x64\xbd\x85\x37\x28\x85\x17\x6b\xf6\xf4\x12\x73\x5f\xb7\xd4\x09\x5c\x64\xab\x2c\x39\xc1\xb5\xb1\x90\xe4\x05\x2b\x92\x70\xe3\x95\x24\x57\x5b\xee\x23\x98\x23\x42\xeb\x7d\xef\x8a\xe5\x52\x1a\xce\x8c\xdd\x2e\x57\x79\x76\x79\x71\xfe\x71\x99\xe7\xab\x8b\x24\x39\x39\xc1\x1d\xfd\x31\xb0\x25\x89\x86\x49\x49\x97\x24\x27\x78\x68\x09\x9d\x60\x0d\x4b\x8e\x84\xad\x5b\xb2\x0e\xac\x77\x46\xed\x48\x66\xd8\xe8\x5a\x0d\x92\x20\x79\xcb\x5e\x28\xb0\x24\xed\xb9\x61\xb2\xf8\x1f\x65\xdb\x2c\xc5\xcd\xdd\x7a\x53\xbe\x4b\x4e\xc0\x0d\x7a\xe3\x1c\x57\x8a\x52\x70\x8c\x8b\xbd\xb5\x84\xde\x52\xc3\xfb\xd0\x26\x6b\xc9\xb5\xf0\x04\xf6\x0e\xfe\xd0\x53\x96\x88\xc1\xb7\xc6\xba\x22\x01\x4e\x13\x00\x68\xd8\x3a\xaf\x45\x47\x05\x16\x5f\x78\x47\xfa\xbb\xe8\x68\xb5\x88\x77\x4a\x3c\x5f\x5d\x8b\x8e\xd5\x61\x76\x27\x9a\x86\x15\x47\x6e\x0b\x2c\x3e\xbd\x7c\x4d\xf7\x2c\x0b\x2c\x62\xb9\x45\x9e\xe7\xf9\x69\x9e\xe7\xab\xd3\xb3\xf3\x8b\xcb\xd3\xf7\x1f\x3e\xfe\x7f\xf1\x76\xfe\xb3\x37\xf2\x9f\xfd\x26\xff\xd9\x2c\xff\xdd\x33\xcd\x9b\xb2\xf8\x79\xba\x3a\x3b\xbf\x38\xbd\x7c\xff\xe1\xe3\x6f\xd2\x9f\xbf\x91\xfe\x7c\x11\x06\xf9\x09\x9e\xbd\xa2\x40\xf2\xa8\x8b\x8a\x46\xee\x87\x4a\xb1\x6b\x49\x86\x09\x9b\xc1\xd6\x94\x25\xf1\x65\x81\xc5\xd5\x5e\x74\xbd\x22\x3c\x84\xef\x11\x45\x4a\x0e\x25\x87\x51\xeb\xc6\xd8\x6e\x92\x6a\x65\x06\x1f\xe1\x8e\x20\x29\xc6\xf1\x0b\x54\x96\xa9\x81\xa8\x82\xae\x6b\x9f\x25\x33\x55\x16\xf8\x33\x01\x8e\x59\x66\x17\x09\xe0\x5b\xe1\x51\x0b\x8d\xda\x68\x1f\x04\xa8\x58\x53\x65\x49\x3c\xba\x04\xa8\x06\x8f\x56\xb8\xd0\x4d\x50\x67\x7c\xc0\x3a\x88\x2f\x16\x94\x85\x5a\xbf\xb2\x87\x69\xf0\x48\x87\x5f\xc6\x4a\xf7\xaa\x3c\xb8\xd6\x0c\x4a\xa2\x22\x08\xe7\x4c\xcd\xc2\x93\xc4\x2f\xf6\x6d\x58\xa6\x40\x2b\x84\x43\x27\xf4\xe1\x25\x5e\xb8\x99\x80\x63\xe2\x47\x7a\x0d\xda\xb0\x96\xa2\x52\x94\x25\xc7\xa0\xa8\x5a\x7c\xa7\xc1\x1a\x57\x33\xe9\x9a\xe2\xc1\x95\xa2\xda\x5b\xd3\xb7\x07\xc7\x46\x99\xed\x61\xac\xb7\x26\xed\xe8\x15\xb1\xc1\x18\x7c\xcb\xee\x65\x38\xb8\x55\x24\x5c\xd8\x19\xb3\x63\x39\x16\xa0\xa6\xc8\x30\x7a\x08\x2d\x97\xc6\x42\x04\xc2\x1e\x43\x9d\xb3\x17\xa1\xb9\x29\x5e\x48\x09\xa1\x9c\x81\x40\x6d\xac\x25\xd7\x1b\x1d\x17\xf2\xeb\x66\x7d\xf5\xfd\xfe\x0a\x0d\x8f\x6a\x19\x3b\xec\x8d\x63\x6f\xec\x21\x4b\x26\xa8\xd0\xd9\x24\xb5\xb5\x25\xe1\x03\x65\x6b\xd3\x75\x46\x3b\xac\xd7\x39\x56\x59\x8e\xdb\xa0\xad\x1a\xa5\x89\x0e\x52\x52\xdc\x6d\x36\x3a\x88\x75\xb0\xaa\xc0\xe2\x68\x49\xf5\x04\x51\x8f\x08\xd1\x9e\xa2\x32\x6b\x19\x83\x97\x4f\x64\xcd\x72\x95\xe5\xcb\x45\x92\x44\xaf\xba\xe9\x27\x1d\x5e\x3f\x7b\xd5\xf5\x30\x76\xf0\x36\x81\xc9\x09\xee\xa9\x17\x36\xb8\x4c\x33\x68\x49\xf6\x99\x37\x6c\xad\xd0\x1e\x7a\xe8\x2a\xb2\xa8\x0e\x08\xe5\x88\x2c\x69\x46\xe0\x71\x98\x8b\xf2\xfa\x4b\x8a\xf2\xfa\x4b\x16\x96\xf3\x72\x31\x1e\x5e\xfd\x48\x71\xf5\xe3\x78\x14\xaa\xb9\x23\x15\x45\x35\xb6\x11\xab\x71\x19\x2c\x35\xc1\xd6\xd0\xf1\xb6\xf5\xa8\xa8\xc0\xc6\xdd\x0f\x7d\xaf\xa8\x23\xed\x1f\x4c\x8a\x8d\x2b\xa7\xfd\x94\x9f\x0f\xe1\xf3\x8e\x1a\xb2\x41\x3a\xf2\xf3\x61\x36\xc0\xa3\x00\xfe\xdd\x7a\xcb\x9b\xcd\xbb\xb9\xed\x66\xe3\x02\x43\xcc\x0c\x37\x4c\x77\x53\xa6\x70\x13\x25\x32\xb4\x1d\x24\xa1\x8c\x4e\x5f\x39\x72\x78\x39\xa3\x70\xe8\x7b\x63\xc3\xfb\xf1\xcc\x41\x58\x2a\x42\xca\x14\xc2\xfe\xe4\x5d\x8a\xdb\x6f\x9b\x32\xb1\xc7\xe2\x67\x06\x1e\x8d\x4e\x1a\x2e\x56\x79\xb6\xdf\xef\x97\x4f\x4f\x4f\x4f\xa3\x7f\x4d\xec\x14\x58\xbc\x66\x65\xbc\x9d\xe4\x76\xfb\x42\xe8\xb3\xbb\xcf\x80\x85\xdd\xf3\xae\xe8\xba\xae\xcb\xb4\xd6\xfa\xbf\x03\x9f\xfd\x0d\xb8\xef\x58\x16\x7a\xfa\xfd\x13\x76\x3e\xa6\xb7\x60\xcf\x8f\xf2\x98\x4c\x23\xfe\xcb\xa1\xa4\x46\x0c\xca\x83\x5d\xfc\xab\x77\xe4\x53\x18\xdf\x92\x7d\x9e\x1e\x76\x42\x0d\x23\xcf\xb8\x37\x8d\xff\x25\x2c\xa5\xf1\xf1\xad\xe8\xc9\xa6\xd8\x74\x62\x4b\x29\x1e\x68\xef\xb3\xe4\x28\xf7\xb1\xbc\x09\x32\xf9\x2b\x00\x00\xff\xff\x5c\x1f\x88\x4f\x73\x08\x00\x00")
+var _confDataciteDataciteYml = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x9c\x56\x4d\x6f\xdb\xba\x12\xdd\xeb\x57\x1c\xd8\x9b\x57\x40\x91\x65\x27\x69\xfb\xb4\x6b\xad\xa4\x30\xd0\x36\x41\x92\x02\xdd\xd2\xe2\xc8\x9a\x17\x8a\xd4\x23\x29\xc7\x0e\xee\x8f\xbf\x20\x25\x27\xf6\x2d\x9a\x02\x37\xab\x48\xe4\x9c\xf9\x38\x67\x8e\x3c\xc5\x37\xf2\x42\x0a\x2f\x50\x1b\x8b\xf2\x66\x05\x4b\x1b\x76\xde\x0a\xcf\x46\x43\x54\x95\xb1\x92\xf5\x06\xde\xa0\x14\x5e\x2c\xd9\xd3\x6b\xcc\x7d\xd5\x50\x2b\x70\x91\xcd\xb3\x64\x8a\x6b\x63\x21\xc9\x0b\x56\x24\xe1\x86\x23\x49\xae\xb2\xdc\x45\x30\x47\x84\xc6\xfb\xce\x15\xb3\x99\x34\x9c\x19\xbb\x99\xcd\xf3\xec\xf2\xe2\xfc\xe3\x2c\xcf\xe7\x17\x49\x32\x9d\xe2\x8e\xfe\xdf\xb3\x25\x89\x9a\x49\x49\x97\x24\x53\x3c\x34\x84\x56\xb0\x86\x25\x47\xc2\x56\x0d\x59\x07\xd6\x5b\xa3\xb6\x24\x33\xac\x74\xa5\x7a\x49\x90\xbc\x61\x2f\x14\x58\x92\xf6\x5c\x33\x59\xfc\x87\xb2\x4d\x96\xe2\xe6\x6e\xb9\x2a\xdf\x25\x53\x70\x8d\xce\x38\xc7\x6b\x45\x29\x38\xc6\xc5\xde\x1a\x42\x67\xa9\xe6\x5d\x68\x93\xb5\xe4\x4a\x78\x02\x7b\x07\xbf\xef\x28\x4b\x44\xef\x1b\x63\x5d\x91\x00\x67\x09\x00\xd4\x6c\x9d\xd7\xa2\xa5\x02\x93\x2f\xbc\x25\xfd\x5d\xb4\x34\x9f\xc4\x33\x25\x5e\x8e\xae\x45\xcb\x6a\x7f\x74\x26\xea\x9a\x15\xc7\xd9\x16\x98\x7c\x7a\x7d\x1a\xcf\x59\x16\x98\xc4\x72\x8b\x3c\xcf\xf3\xb3\x3c\xcf\xe7\x67\x8b\xf3\x8b\xcb\xb3\xf7\x1f\x3e\xfe\x77\xf2\x76\xfe\xc5\x1b\xf9\x17\x7f\xc8\xbf\x38\xca\x7f\xf7\x32\xe6\x55\x59\xfc\x3c\x9b\x2f\xce\x2f\xce\x2e\xdf\x7f\xf8\xf8\x87\xf4\xe7\x6f\xa4\x3f\x9f\x04\x22\x3f\xc1\xb3\x57\x14\x86\x3c\xe8\x62\x4d\xc3\xec\xfb\xb5\x62\xd7\x90\x0c\x0c\x9b\xde\x56\x94\x25\xf1\x66\x81\xc9\xd5\x4e\xb4\x9d\x22\x3c\x84\xe7\x01\x45\x4a\x0e\x25\x07\xaa\x75\x6d\x6c\x3b\x4a\x75\x6d\x7a\x1f\xe1\x0e\x20\x29\x06\xfa\x05\xd6\x96\xa9\x86\x58\x07\x5d\x57\x3e\x4b\x8e\x54\x59\xe0\xaf\x04\x38\x64\x39\x3a\x48\x00\xdf\x08\x8f\x4a\x68\x54\x46\xfb\x20\x40\xc5\x9a\xd6\x96\xc4\xa3\x4b\x80\x75\xef\xd1\x08\x17\xba\x09\xea\x8c\x17\x58\x07\xf1\xc5\x82\xb2\x50\xeb\x57\xf6\x30\x35\x1e\x69\xff\x64\xac\x74\x27\xe5\xc1\x35\xa6\x57\x12\x6b\x82\x70\xce\x54\x2c\x3c\x49\x3c\xb1\x6f\xc2\x32\x85\xb1\x42\x38\xb4\x42\xef\x5f\xe3\x85\x3b\x12\x70\x4c\xfc\x48\xa7\xa0\x35\x6b\x29\xd6\x8a\xb2\xe4\x10\x14\x55\x8b\xef\xd4\x5b\xe3\x2a\x26\x5d\x51\x7c\x71\xa5\xa8\xf2\xd6\x74\xcd\xde\xb1\x51\x66\xb3\x1f\xea\xad\x48\x3b\x3a\x19\x6c\x30\x06\xdf\xb0\x7b\x25\x07\xb7\x8a\x84\x0b\x3b\x63\xb6\x2c\x87\x02\xd4\x18\x19\xa8\x87\xd0\x72\x66\x2c\x44\x18\xd8\x63\xa8\xf3\xe8\x46\x68\x6e\x8c\x17\x52\x42\x28\x67\x20\x50\x19\x6b\xc9\x75\x46\xc7\x85\xfc\xba\x5a\x5e\x7d\xbf\xbf\x42\xcd\x83\x5a\x86\x0e\x3b\xe3\xd8\x1b\xbb\xcf\x92\x11\x2a\x74\x36\x4a\x6d\x69\x49\xf8\x30\xb2\xa5\x69\x5b\xa3\x1d\x96\xcb\x1c\xf3\x2c\xc7\x6d\xd0\x56\x85\xd2\x44\x07\x29\x29\xee\x36\x1b\x1d\xc4\xda\x5b\x55\x60\x72\xb0\xa4\x6a\x84\xa8\x06\x84\x68\x4f\x51\x99\x95\x8c\xc1\xb3\x67\xb2\x66\x36\xcf\xf2\xd9\x24\x49\xa2\x57\xdd\x74\xa3\x0e\xaf\x5f\xbc\xea\xba\x1f\x3a\x78\x7b\x80\xc9\x14\xf7\xd4\x09\x1b\x5c\xa6\xee\xb5\x24\xfb\x32\x37\x6c\xac\xd0\x1e\xba\x6f\xd7\x64\xb1\xde\x23\x94\x23\xb2\xa4\x1e\x80\x07\x32\x27\xe5\xf5\x97\x14\xe5\xf5\x97\x2c\x2c\xe7\xe5\x64\x78\x79\xf5\x23\xc5\xd5\x8f\xc3\xab\x50\xcd\x1d\xa9\x28\xaa\xa1\x8d\x58\x8d\xcb\x60\xa9\x0e\xb6\x86\x96\x37\x8d\xc7\x9a\x0a\xac\xdc\x7d\xdf\x75\x8a\x5a\xd2\xfe\xc1\xa4\x58\xb9\x72\xdc\x4f\xf9\x79\x1f\x1e\xef\xa8\x26\x1b\xa4\x23\x3f\xef\x8f\x08\x3c\x08\xe0\xf7\xd6\x5b\xde\xac\xde\x1d\xdb\x6e\x36\x2c\x30\xc4\x91\xe1\x06\x76\x57\x65\x0a\x37\x8e\x44\x86\xb6\x83\x24\x94\xd1\xe9\x89\x23\x87\x9b\x47\x23\xec\xbb\xce\xd8\x70\x7f\x78\xe7\x20\x2c\x15\x21\x65\x0a\x61\x7f\xf2\x36\xc5\xed\xb7\x55\x99\x4c\xb1\xd2\x31\xb4\x62\x3f\x32\x12\xf8\x4a\xd1\xfd\x2a\xe3\xba\x57\x2a\x0c\x68\xe8\xf6\xe4\x23\x11\x0c\x28\xc5\xf8\x29\x48\xf1\x3f\xd3\xdb\xc0\x3d\xf9\x2a\x4b\x5e\x22\x8e\xbe\x11\xd1\x4b\xa5\xe1\x62\x9e\x67\xbb\xdd\x6e\xf6\xfc\xfc\xfc\x3c\x58\xe4\x48\x40\x81\xc9\xe9\xe0\x87\xd3\x43\x95\x41\xd5\xe3\xbf\xf3\xc9\x29\xaa\xb0\x3b\xde\x16\x6d\xdb\xb6\x99\xd6\x5a\xff\x4b\xd4\xc5\x3f\x50\xbb\x96\x65\xa1\xc7\xbf\x5f\x31\x8f\x35\xf0\x5b\xcc\xf3\x83\xf0\x46\x3b\x8a\xdf\x4f\x94\x54\x8b\x5e\x79\xb0\x8b\x3f\x22\x1c\xf9\x14\xc6\x37\x64\x5f\x74\x81\xad\x50\xfd\xc0\x20\xee\x4d\xed\x9f\x84\xa5\x34\x5e\xbe\x15\x1d\xd9\x14\xab\x56\x6c\x28\xc5\x03\xed\x7c\x18\xf7\x00\x3f\xd4\x36\x42\x86\xbc\xa5\x81\x36\x1e\x24\x83\xef\x5a\x58\x6a\xcd\x76\x24\xd6\x28\x65\x9e\x02\x91\xc1\xc4\x13\x4f\x6d\x17\x76\x63\x4b\xd6\xc5\x0e\xe6\xd9\x22\xf9\x3b\x00\x00\xff\xff\x36\x4c\x85\xec\x0e\x09\x00\x00")
 
 func confDataciteDataciteYmlBytes() ([]byte, error) {
 	return bindataRead(
@@ -336,7 +336,7 @@ func confDataciteDataciteYml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/datacite/datacite.yml", size: 2163, mode: os.FileMode(432), modTime: time.Unix(1576589367, 0)}
+	info := bindataFileInfo{name: "conf/datacite/datacite.yml", size: 2318, mode: os.FileMode(432), modTime: time.Unix(1578063794, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1436,7 +1436,7 @@ func confGitignoreGo() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/gitignore/Go", size: 266, mode: os.FileMode(432), modTime: time.Unix(1561643584, 0)}
+	info := bindataFileInfo{name: "conf/gitignore/Go", size: 266, mode: os.FileMode(432), modTime: time.Unix(1577112094, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4036,7 +4036,7 @@ func confLicenseCreativeCommonsCc010PublicDomainDedication() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/license/Creative Commons CC0 1.0 Public Domain Dedication", size: 6894, mode: os.FileMode(432), modTime: time.Unix(1576589367, 0)}
+	info := bindataFileInfo{name: "conf/license/Creative Commons CC0 1.0 Public Domain Dedication", size: 6894, mode: os.FileMode(432), modTime: time.Unix(1577104923, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4416,7 +4416,7 @@ func confLocaleLocale_bgBgIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_bg-BG.ini", size: 96539, mode: os.FileMode(432), modTime: time.Unix(1576589429, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_bg-BG.ini", size: 96539, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4436,7 +4436,7 @@ func confLocaleLocale_csCzIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_cs-CZ.ini", size: 70498, mode: os.FileMode(432), modTime: time.Unix(1576589430, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_cs-CZ.ini", size: 70498, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4456,7 +4456,7 @@ func confLocaleLocale_deDeIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_de-DE.ini", size: 71113, mode: os.FileMode(432), modTime: time.Unix(1576589430, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_de-DE.ini", size: 71113, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4476,7 +4476,7 @@ func confLocaleLocale_enGbIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_en-GB.ini", size: 63919, mode: os.FileMode(432), modTime: time.Unix(1576775257, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_en-GB.ini", size: 63919, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4496,7 +4496,7 @@ func confLocaleLocale_enUsIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_en-US.ini", size: 67051, mode: os.FileMode(432), modTime: time.Unix(1576775001, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_en-US.ini", size: 67051, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4516,7 +4516,7 @@ func confLocaleLocale_esEsIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_es-ES.ini", size: 71914, mode: os.FileMode(432), modTime: time.Unix(1576592940, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_es-ES.ini", size: 71914, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4536,7 +4536,7 @@ func confLocaleLocale_faIrIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_fa-IR.ini", size: 90359, mode: os.FileMode(432), modTime: time.Unix(1576589429, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_fa-IR.ini", size: 90359, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4556,7 +4556,7 @@ func confLocaleLocale_fiFiIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_fi-FI.ini", size: 68016, mode: os.FileMode(432), modTime: time.Unix(1576589430, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_fi-FI.ini", size: 68016, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4576,7 +4576,7 @@ func confLocaleLocale_frFrIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_fr-FR.ini", size: 72343, mode: os.FileMode(432), modTime: time.Unix(1576589430, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_fr-FR.ini", size: 72343, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4596,7 +4596,7 @@ func confLocaleLocale_glEsIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_gl-ES.ini", size: 69771, mode: os.FileMode(432), modTime: time.Unix(1576589430, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_gl-ES.ini", size: 69771, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4616,7 +4616,7 @@ func confLocaleLocale_huHuIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_hu-HU.ini", size: 71018, mode: os.FileMode(432), modTime: time.Unix(1576589430, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_hu-HU.ini", size: 71018, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4636,7 +4636,7 @@ func confLocaleLocale_idIdIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_id-ID.ini", size: 66323, mode: os.FileMode(432), modTime: time.Unix(1576589429, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_id-ID.ini", size: 66323, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4656,7 +4656,7 @@ func confLocaleLocale_itItIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_it-IT.ini", size: 68598, mode: os.FileMode(432), modTime: time.Unix(1576589430, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_it-IT.ini", size: 68598, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4676,7 +4676,7 @@ func confLocaleLocale_jaJpIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_ja-JP.ini", size: 81009, mode: os.FileMode(432), modTime: time.Unix(1576589430, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_ja-JP.ini", size: 81009, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4696,7 +4696,7 @@ func confLocaleLocale_koKrIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_ko-KR.ini", size: 71166, mode: os.FileMode(432), modTime: time.Unix(1576589429, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_ko-KR.ini", size: 71166, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4716,7 +4716,7 @@ func confLocaleLocale_lvLvIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_lv-LV.ini", size: 71069, mode: os.FileMode(432), modTime: time.Unix(1576589430, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_lv-LV.ini", size: 71069, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4736,7 +4736,7 @@ func confLocaleLocale_nlNlIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_nl-NL.ini", size: 66875, mode: os.FileMode(432), modTime: time.Unix(1576589430, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_nl-NL.ini", size: 66875, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4756,7 +4756,7 @@ func confLocaleLocale_plPlIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_pl-PL.ini", size: 69359, mode: os.FileMode(432), modTime: time.Unix(1576589430, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_pl-PL.ini", size: 69359, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4776,7 +4776,7 @@ func confLocaleLocale_ptBrIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_pt-BR.ini", size: 69490, mode: os.FileMode(432), modTime: time.Unix(1576589430, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_pt-BR.ini", size: 69490, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4796,7 +4796,7 @@ func confLocaleLocale_ptPtIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_pt-PT.ini", size: 70307, mode: os.FileMode(432), modTime: time.Unix(1576589429, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_pt-PT.ini", size: 70307, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4816,7 +4816,7 @@ func confLocaleLocale_ruRuIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_ru-RU.ini", size: 101278, mode: os.FileMode(432), modTime: time.Unix(1576592955, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_ru-RU.ini", size: 101278, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4836,7 +4836,7 @@ func confLocaleLocale_skSkIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_sk-SK.ini", size: 70596, mode: os.FileMode(432), modTime: time.Unix(1576589429, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_sk-SK.ini", size: 70596, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4856,7 +4856,7 @@ func confLocaleLocale_srSpIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_sr-SP.ini", size: 93153, mode: os.FileMode(432), modTime: time.Unix(1576589430, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_sr-SP.ini", size: 93153, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4876,7 +4876,7 @@ func confLocaleLocale_svSeIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_sv-SE.ini", size: 66876, mode: os.FileMode(432), modTime: time.Unix(1576589430, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_sv-SE.ini", size: 66876, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4896,7 +4896,7 @@ func confLocaleLocale_trTrIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_tr-TR.ini", size: 69816, mode: os.FileMode(432), modTime: time.Unix(1576589430, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_tr-TR.ini", size: 69816, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4916,7 +4916,7 @@ func confLocaleLocale_ukUaIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_uk-UA.ini", size: 98784, mode: os.FileMode(432), modTime: time.Unix(1576589430, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_uk-UA.ini", size: 98784, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4936,7 +4936,7 @@ func confLocaleLocale_viVnIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_vi-VN.ini", size: 75198, mode: os.FileMode(432), modTime: time.Unix(1576589429, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_vi-VN.ini", size: 75198, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4956,7 +4956,7 @@ func confLocaleLocale_zhCnIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_zh-CN.ini", size: 62875, mode: os.FileMode(432), modTime: time.Unix(1576589429, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_zh-CN.ini", size: 62875, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4976,7 +4976,7 @@ func confLocaleLocale_zhHkIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_zh-HK.ini", size: 63260, mode: os.FileMode(432), modTime: time.Unix(1576589429, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_zh-HK.ini", size: 63260, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4996,7 +4996,7 @@ func confLocaleLocale_zhTwIni() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "conf/locale/locale_zh-TW.ini", size: 62498, mode: os.FileMode(432), modTime: time.Unix(1576592979, 0)}
+	info := bindataFileInfo{name: "conf/locale/locale_zh-TW.ini", size: 62498, mode: os.FileMode(432), modTime: time.Unix(1577105123, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -219,7 +219,7 @@ figure figcaption {
   font-style: italic;
   text-align: justify;
 }
-#cloudberry-view {
+#datacite-view {
   margin-top: 14px;
 }
 .ui.codetab {

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -201,39 +201,6 @@ footer {
   text-align: left;
 }
 .leftspace {
-  padding-left: 20px;
-}
-figure {
-  float: right;
-  max-width: 600px;
-}
-figure img {
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
-}
-figure figcaption {
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
-  font-style: italic;
-  text-align: justify;
-}
-#cloudberry-view {
-  margin-top: 14px;
-}
-.ui.codetab {
-  padding: 0;
-}
-#file-buttons {
-  padding-right: 5px;
-}
-.supersmall {
-  padding-left: 10px;
-  font-size: 0.8em;
-  text-align: left;
-}
-.leftspace {
   padding-left: 40px;
 }
 figure {

--- a/templates/repo/doifile.tmpl
+++ b/templates/repo/doifile.tmpl
@@ -1,4 +1,4 @@
-<div id = "cloudberry-view" class="tab-size-8">
+<div id = "datacite-view" class="tab-size-8">
 	<table class="ui fixed single line table">
 		<thead>
 			<tr>

--- a/templates/repo/doifile.tmpl
+++ b/templates/repo/doifile.tmpl
@@ -1,70 +1,70 @@
 <div id = "cloudberry-view" class="tab-size-8">
-		<table class="ui fixed single line table">
+	<table class="ui fixed single line table">
 		<thead>
-    		<tr>
-    			<th class="two wide">
-			<i class="octicon octicon-squirrel"></i>
-						<strong>Datacite.yml</strong>
-    			</th>
-    			<th class="fourteen wide">
-    			</th>
-    		</tr>
-    	</thead>
-				<tbody>
+			<tr>
+				<th class="two wide">
+					<i class="octicon octicon-squirrel"></i>
+					<strong>Datacite.yml</strong>
+				</th>
+				<th class="fourteen wide">
+				</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>Title</td>
+				<td>{{.DOIInfo.Title}}</td>
+			</tr>
+			<tr>
+				<td>Authors</td>
+				<td>
+					{{range $index, $auth := .DOIInfo.Authors}}
+						{{ $auth.RenderAuthor }}
+						<br>
+					{{end}}
+				</td>
+			</tr>
+			{{if .DOIInfo.Description}}
 				<tr>
-						<td>Title</td>
-						<td>{{.DOIInfo.Title}}</td>
+					<td>Description</td>
+					<td>{{.DOIInfo.Description}}
+					</td>
 				</tr>
+			{{end}}
+			{{if .DOIInfo.License}}
 				<tr>
-						<td>Authors</td>
-						<td>
-								{{range $index, $auth := .DOIInfo.Authors}}
-								{{ $auth.RenderAuthor }}
-								<br>
-								{{end}}
-						</td>
+					<td>License</td>
+					<td>{{.DOIInfo.License.Name}} ({{.DOIInfo.License.URL}})
+					</td>
 				</tr>
-				{{if .DOIInfo.Description}}
+			{{end}}
+			<tr>
+				<td>References</td>
+				<td>
+					{{range $index, $ref := .DOIInfo.References}}
+						{{ $ref.Name }} [{{ $ref.ID }}] ({{ $ref.Reftype }})
+						<br>
+					{{end}}
+				</td>
+			</tr>
+			<tr>
+				<td>Funding</td>
+				<td>
+					{{range $index, $ref := .DOIInfo.Funding}}
+						{{ $ref}}
+						<br>
+					{{end}}
+				</td>
+			</tr>
+			{{if .DOIInfo.Keywords}}
 				<tr>
-						<td>Description</td>
-						<td>{{.DOIInfo.Description}}
-						</td>
-				</tr>
-				{{end}}
-				{{if .DOIInfo.License}}
-				<tr>
-						<td>License</td>
-						<td>{{.DOIInfo.License.Name}} ({{.DOIInfo.License.URL}})
-						</td>
-				</tr>
-				{{end}}
-				<tr>
-						<td>References</td>
-						<td>
-								{{range $index, $ref := .DOIInfo.References}}
-								{{ $ref.Name }} [{{ $ref.ID }}] ({{ $ref.Reftype }})
-								<br>
-								{{end}}
-						</td>
-				</tr>
-				<tr>
-						<td>Funding</td>
-						<td>
-								{{range $index, $ref := .DOIInfo.Funding}}
-								{{ $ref}}
-								<br>
-								{{end}}
-						</td>
-				</tr>
-				{{if .DOIInfo.Keywords}}
-				<tr>
-						<td>Keywords</td>
-						<td>
-								{{range $index, $sub := .DOIInfo.Keywords}}
-								{{ $sub }}
-								<br>
-								{{end}}
-						</td>
+					<td>Keywords</td>
+					<td>
+						{{range $index, $sub := .DOIInfo.Keywords}}
+							{{ $sub }}
+							<br>
+						{{end}}
+					</td>
 				</tr>
 				<tr>
 					<td>Resource Type</td>
@@ -72,8 +72,8 @@
 						<i>{{.DOIInfo.GetType}}</i><br>
 					</td>
 				</tr>
-				{{end}}
-				</tbody>
-		</table>
-		</div>
+			{{end}}
+		</tbody>
+	</table>
+</div>
 </div>

--- a/templates/repo/doifile.tmpl
+++ b/templates/repo/doifile.tmpl
@@ -42,7 +42,7 @@
 				<td>References</td>
 				<td>
 					{{range $index, $ref := .DOIInfo.References}}
-						{{ $ref.Name }} [{{ $ref.ID }}] ({{ $ref.Reftype }})
+						{{ $ref.Name }} {{ $ref.Citation }} [{{ $ref.ID }}] ({{ $ref.Reftype }})
 						<br>
 					{{end}}
 				</td>

--- a/templates/repo/doifile.tmpl
+++ b/templates/repo/doifile.tmpl
@@ -2,9 +2,9 @@
 	<table class="ui fixed single line table">
 		<thead>
 			<tr>
-				<th class="two wide">
+				<th class="three wide">
 					<i class="octicon octicon-squirrel"></i>
-					<strong>Datacite.yml</strong>
+					<strong>datacite.yml</strong>
 				</th>
 				<th class="fourteen wide">
 				</th>

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -101,10 +101,11 @@
 							<div class="content">
 								<div class="ui header">So you want to download data without special tooling (e.g. git, git-annex or GIN)?</div>
 								<p>Here is what you can do:</p>
-								<p>Download the small files and the file structure as an archive (zip or tar). The big files will be
-									included namewise but the data will not be there. To get the content of the big files you need to download them individually from the web interface. This way you can get the file structure but the heavy loads only on demand!</p>
-								<p>Download the small files as GIN archive(*.gin.zip). This is comparable to the situation above, however,
-									you also get the history of the files and the possibility  to request the big  files via git-annex or the GIN-client.</p>
+								<p>Download the small files and the file structure as an archive (.zip or .tar.gz). Annexed files (by default, files larger than 10 MB) will be
+								included as pointer files (stubs) but the data will not be included. To get the content of the big files you need to download them individually
+								from this web page.</p>
+								<p>Download the small files as a GIN archive (.gin.zip). This includes all the git information,
+								including the history of the repository and the possibility to download the content of large files using git annex or the GIN client.</p>
 							</div>
 							<div class="actions">
 								<a class="ui positive button" href="{{$.RepoLink}}/archive/{{EscapePound $.BranchName}}.zip"><i class="octicon octicon-file-zip"></i> Download zip</a>

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -69,7 +69,7 @@
 					</div>
 				{{end}}
 
-				<!-- Only show colne panel in repository home page -->
+				<!-- Only show clone panel in repository home page -->
 				{{ $n := len .TreeNames}}
 				{{ $l := Subtract $n 1}}
 				{{if eq $n 0}}
@@ -95,7 +95,7 @@
 						<i class="download icon"></i>
 						</div>
 
-						<!-- Download moddal -->
+						<!-- Download modal -->
 						<div id="download_modal" class="ui modal warning">
 							<i class="close icon"></i>
 							<div class="content">

--- a/vendor/github.com/G-Node/libgin/libgin/doi.go
+++ b/vendor/github.com/G-Node/libgin/libgin/doi.go
@@ -1,10 +1,8 @@
 package libgin
 
 import (
-	"bytes"
 	"crypto/md5"
 	"encoding/hex"
-	"encoding/xml"
 	"fmt"
 	"log"
 	"net/http"
@@ -15,9 +13,12 @@ import (
 
 // NOTE: TEMPORARY COPIES FROM gin-doi
 
-// uuidMap is a map between registered repositories and their UUIDs for datasets registered before the new UUID generation method was implemented.
-// This map is required because the current method of computing UUIDs differs from the older method and this lookup is used to handle the old-method UUIDs.
-var uuidMap = map[string]string{
+// UUIDMap is a map between registered repositories and their UUIDs for
+// datasets registered before the new UUID generation method was implemented.
+// This map is required because the current method of computing UUIDs differs
+// from the older method and this lookup is used to handle the old-method
+// UUIDs.
+var UUIDMap = map[string]string{
 	"INT/multielectrode_grasp":                   "f83565d148510fede8a277f660e1a419",
 	"ajkumaraswamy/HB-PAC_disinhibitory_network": "1090f803258557299d287c4d44a541b2",
 	"steffi/Kleineidam_et_al_2017":               "f53069de4c4921a3cfa8f17d55ef98bb",
@@ -27,7 +28,7 @@ var uuidMap = map[string]string{
 
 // RepoPathToUUID computes a UUID from a repository path.
 func RepoPathToUUID(URI string) string {
-	if doi, ok := uuidMap[URI]; ok {
+	if doi, ok := UUIDMap[URI]; ok {
 		return doi
 	}
 	currMd5 := md5.Sum([]byte(URI))
@@ -45,18 +46,21 @@ type DOIRequestData struct {
 
 // DOIRegInfo holds all the metadata and information necessary for a DOI registration request.
 type DOIRegInfo struct {
-	Missing      []string
-	DOI          string
-	UUID         string
-	FileSize     int64
-	Title        string
-	Authors      []Author
-	Description  string
-	Keywords     []string
-	References   []Reference
-	Funding      []string
-	License      *License
-	ResourceType string
+	Missing         []string
+	DOI             string
+	UUID            string
+	FileName        string
+	FileSize        string
+	Title           string
+	Authors         []Author
+	Description     string
+	Keywords        []string
+	References      []Reference
+	Funding         []string
+	License         *License
+	ResourceType    string
+	DateTime        time.Time
+	TemplateVersion string
 }
 
 func (c *DOIRegInfo) GetType() string {
@@ -75,17 +79,15 @@ func (c *DOIRegInfo) GetCitation() string {
 			authors += fmt.Sprintf("%s, ", auth.LastName)
 		}
 	}
-	return fmt.Sprintf("%s (%d) %s. G-Node. doi:%s", authors, time.Now().Year(), c.Title, c.DOI)
+	return fmt.Sprintf("%s (%s) %s. G-Node. doi:%s", authors, c.Year(), c.Title, c.DOI)
 }
 
-func (c *DOIRegInfo) EscXML(txt string) string {
-	buf := new(bytes.Buffer)
-	if err := xml.EscapeText(buf, []byte(txt)); err != nil {
-		log.Printf("Could not escape: %s :: %s", txt, err.Error())
-		return ""
-	}
-	return buf.String()
+func (c *DOIRegInfo) Year() string {
+	return fmt.Sprintf("%d", c.DateTime.Year())
+}
 
+func (c *DOIRegInfo) ISODate() string {
+	return c.DateTime.Format("2006-01-02")
 }
 
 type Author struct {
@@ -119,9 +121,37 @@ type NamedIdentifier struct {
 }
 
 type Reference struct {
-	Reftype string
-	Name    string
-	ID      string
+	Reftype  string
+	Name     string
+	Citation string
+	ID       string
+}
+
+func (ref Reference) GetURL() string {
+	idparts := strings.SplitN(ref.ID, ":", 2)
+	if len(idparts) != 2 {
+		// Malformed ID (no colon)
+		return ""
+	}
+	source := idparts[0]
+	idnum := idparts[1]
+
+	var prefix string
+	switch strings.ToLower(source) {
+	case "doi":
+		prefix = "https://doi.org/"
+	case "arxiv":
+		// https://arxiv.org/help/arxiv_identifier_for_services
+		prefix = "https://arxiv.org/abs/"
+	case "pmid":
+		// https://www.ncbi.nlm.nih.gov/books/NBK3862/#linkshelp.Retrieve_PubMed_Citations
+		prefix = "https://www.ncbi.nlm.nih.gov/pubmed/"
+	default:
+		// Return an empty string to make the reflink inactive
+		return ""
+	}
+
+	return fmt.Sprintf("%s%s", prefix, idnum)
 }
 
 type License struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/G-Node/git-module v0.8.4-gnode
 github.com/G-Node/git-module
-# github.com/G-Node/libgin v0.3.1
+# github.com/G-Node/libgin v0.3.2
 github.com/G-Node/libgin/libgin
 github.com/G-Node/libgin/libgin/annex
 github.com/G-Node/libgin/libgin/gig


### PR DESCRIPTION
**Depends on G-Node/libgin#5.**

### Reference Citation
This PR uses the Citation field to the Reference struct, which is intended to replace Name.

Currently, both Name and Citation are allowed and are concatenated when rendering landing pages and doi.xml files, but the `Name` field will be phased out as we update GIN Web and update the datacite.yml templates and documentation.  The Name field will continue to be rendered in repository front pages even after we have phased it out, to continue supporting older datacite.yml files.  There's a new `TemplateVersion` field which isn't used yet, but will be used in the future to control the file rendering.

### Additional changes
- Minor adjustments to frontend text and rendering:
    - Small rephrasing of archive download option descriptions.
    - Wider first column for field names in datacite.yml rendering, to make the filename more likely to be fully visible.
- Deleted duplicate entries in our custom.css.