### PR TITLE
ENH: route to .git/{config,annex/objects} and allow HEAD requests

### DIFF
--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -666,10 +666,10 @@ func runWeb(c *cli.Context) error {
 		m.Group("/:reponame([\\d\\w-_\\.]+\\.git$)", func() {
 			m.Get("", ignSignIn, context.RepoAssignment(), context.RepoRef(), repo.Home)
 			m.Options("/*", ignSignInAndCsrf, repo.HTTPContexter(), repo.HTTP)
-			m.Route("/*", "GET,POST", ignSignInAndCsrf, repo.HTTPContexter(), repo.HTTP)
+			m.Route("/*", "GET,POST,HEAD", ignSignInAndCsrf, repo.HTTPContexter(), repo.HTTP)
 		})
 		m.Options("/:reponame/*", ignSignInAndCsrf, repo.HTTPContexter(), repo.HTTP)
-		m.Route("/:reponame/*", "GET,POST", ignSignInAndCsrf, repo.HTTPContexter(), repo.HTTP)
+		m.Route("/:reponame/*", "GET,POST,HEAD", ignSignInAndCsrf, repo.HTTPContexter(), repo.HTTP)
 	})
 	// ***** END: Repository *****
 

--- a/internal/route/repo/http.go
+++ b/internal/route/repo/http.go
@@ -325,6 +325,11 @@ func getTextFile(h serviceHandler) {
 	h.sendFile("text/plain")
 }
 
+func getBinaryFile(h serviceHandler) {
+	h.setHeaderNoCache()
+	h.sendFile("application/octet-stream")
+}
+
 func getInfoPacks(h serviceHandler) {
 	h.setHeaderCacheForever()
 	h.sendFile("text/plain; charset=utf-8")
@@ -366,7 +371,7 @@ var routes = []struct {
 	// TODO: we probably just need to provide some getBinaryFile
 	// Note: code below treats HEAD (used by git annex drop to sense presence)
 	// as "GET" for the purpose of allowing or not the route
-	{regexp.MustCompile("(.*?)/annex/objects/.*/.*-s[0-9]*--.*"), "GET", getTextFile},
+	{regexp.MustCompile("(.*?)/annex/objects/.*/.*-s[0-9]*--.*"), "GET", getBinaryFile},
 }
 
 func getGitRepoPath(dir string) (string, error) {


### PR DESCRIPTION
This allows to access public git-annex repos via http without requiring
going through SSH or some other fanciness (e.g. special remote).

Notes:

- I have no clue in Go, or in any of the frameworks used here, so my
  solution could be very suboptimal.

- URL should end in .git/ since stored repos are bare

- I have not tested if somehow this errorneously enables access to
  annexed files in private repos (I would asume not)

- I have tested only 'get' and 'drop' functionality on a basic example
  running a local instance of gin/gogs.  I had to set

  annex.security.allowed-http-addresses=all

  config since it was running from localhost

Actual minor TODOs left for someone to finish up

- [ ] I think that there is a bit more to be done to support resuming downloads
  That seems to be revealed also by running annex testremote on it:

<details><summary>protocol of running testremote</summary>

```shell
	$> git annex testremote origin --test-readonly 1.mp3
	testremote origin Remote Tests
	  dropping from http remote not supported
	  unavailable remote
		removeKey:                       OK
		storeKey:                        FAIL
		  ./Command/TestRemote.hs:276:
		  (got: Left "copying to non-ssh repo not supported")
		checkPresent:                    OK
		retrieveKeyFile:                 download failed: ConnectionFailure Network.Socket.getAddrInfo (called with preferred socket type/protocol: AddrInfo {addrFlags = [AI_ADDRCONFIG], addrFamily = AF_UNSPEC, addrSocketType = Stream, addrProtocol = 0, addrAddress = <assumed to be undefined>, addrCanonName = <assumed to be undefined>}, host name: Just "!dne!", service name: Just "3000"): does not exist (Name or service not known)
	download failed: ConnectionFailure Network.Socket.getAddrInfo (called with preferred socket type/protocol: AddrInfo {addrFlags = [AI_ADDRCONFIG], addrFamily = AF_UNSPEC, addrSocketType = Stream, addrProtocol = 0, addrAddress = <assumed to be undefined>, addrCanonName = <assumed to be undefined>}, host name: Just "!dne!", service name: Just "3000"): does not exist (Name or service not known)
	OK
		retrieveKeyFileCheap:            OK
	  key size Just 6951961; NoChunks; encryption none
		present True:                    OK (0.03s)
		retrieveKeyFile:                 OK (0.11s)
		fsck downloaded object:          OK
		retrieveKeyFile resume from 33%: OK (0.07s)
		fsck downloaded object:          OK
		retrieveKeyFile resume from 0:   OK (0.09s)
		fsck downloaded object:          OK
		retrieveKeyFile resume from end: download failed: ResponseBodyTooShort 6951961 33
	download failed: Not Found
	FAIL (0.04s)
		  ./Command/TestRemote.hs:198:
		  failed
		fsck downloaded object:          OK

	2 out of 14 tests failed (0.37s)
```
</details>

edit1: log dumped to the screen says

```
[Macaron] 2020-02-02 20:56:05: Completed GET /yarikoptic/test1.git/annex/objects/a87/ada/SHA256E-s6951961--c6f5b8b9c402f2e6c1b5cb00fb5c99600cbb5291f4df7245b64efebcecb79909.mp3/SHA256E-s6951961--c6f5b8b9c402f2e6c1b5cb00fb5c99600cbb5291f4df7245b64efebcecb79909.mp3 416 Requested Range Not Satisfiable
```
actually -- so it fails to "resume" on an already completed download. i.e. as the test message says:

```
retrieveKeyFile resume from end: download failed: ResponseBodyTooShort 6951961 33
```
so it is from the end.  So literally it shouldn't download a byte more and just "complete" peacefully. I think it is a bug somewhere in gogs/underlying libraries. may be just in how it provides its 416 error code, since https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/416 seems to demand some information.

- [x] getTextFile is probably not kosher for binary files. will improve in the
      next commit

that 2nd failure is the one hinting on inability to retreave if previous one
was interrupted (running datalad clean or just removing those
.git/annex/transfer and should mitigate

Attn @mih