### PR TITLE
HOTFIX: Create paths for nested web uploads

### DIFF
--- a/models/repo_editor.go
+++ b/models/repo_editor.go
@@ -492,6 +492,10 @@ func (repo *Repository) UploadRepoFiles(doer *User, opts UploadRepoFileOptions) 
 		}
 
 		targetPath := path.Join(dirPath, upload.Name)
+		// GIN: Create subdirectory for dirtree uploads
+		if err = os.MkdirAll(filepath.Dir(targetPath), os.ModePerm); err != nil {
+			return fmt.Errorf("mkdir: %v", err)
+		}
 		if err = com.Copy(tmpPath, targetPath); err != nil {
 			return fmt.Errorf("copy: %v", err)
 		}


### PR DESCRIPTION
For each file, calls MkdirAll for the parent directory.