### PR TITLE
Add API endpoints to manage Organisation Teams

### DIFF
--- a/internal/route/api/v1/api.go
+++ b/internal/route/api/v1/api.go
@@ -5,14 +5,15 @@
 package v1
 
 import (
+	"net/http"
+	"strings"
+
 	admin2 "github.com/G-Node/gogs/internal/route/api/v1/admin"
 	misc2 "github.com/G-Node/gogs/internal/route/api/v1/misc"
 	org2 "github.com/G-Node/gogs/internal/route/api/v1/org"
 	repo2 "github.com/G-Node/gogs/internal/route/api/v1/repo"
 	search2 "github.com/G-Node/gogs/internal/route/api/v1/search"
 	user2 "github.com/G-Node/gogs/internal/route/api/v1/user"
-	"net/http"
-	"strings"
 
 	"github.com/go-macaron/binding"
 	"gopkg.in/macaron.v1"
@@ -368,7 +369,11 @@ func RegisterRoutes(m *macaron.Macaron) {
 			m.Combo("").
 				Get(org2.Get).
 				Patch(bind(api.EditOrgOption{}), org2.Edit)
-			m.Get("/teams", org2.ListTeams)
+			m.Group("/teams", func() {
+				m.Combo("").
+					Get(org2.ListTeams).
+					Post(bind(api.CreateTeamOption{}), org2.CreateTeam)
+			})
 		}, orgAssignment(true))
 
 		m.Group("/admin", func() {

--- a/internal/route/api/v1/api.go
+++ b/internal/route/api/v1/api.go
@@ -373,6 +373,10 @@ func RegisterRoutes(m *macaron.Macaron) {
 				m.Combo("").
 					Get(org2.ListTeams).
 					Post(bind(api.CreateTeamOption{}), org2.CreateTeam)
+				m.Combo("/:team").
+					Get(org2.GetTeam).
+					Patch(bind(api.CreateTeamOption{}), org2.EditTeam).
+					Delete(org2.DeleteTeam)
 			})
 		}, orgAssignment(true))
 

--- a/internal/route/api/v1/org/team.go
+++ b/internal/route/api/v1/org/team.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/G-Node/gogs/internal/db"
+	"github.com/G-Node/gogs/internal/db/errors"
 	convert2 "github.com/G-Node/gogs/internal/route/api/v1/convert"
 	api "github.com/gogs/go-gogs-client"
 
@@ -29,12 +30,13 @@ func ListTeams(c *context.APIContext) {
 }
 
 func CreateTeam(c *context.APIContext, opt api.CreateTeamOption) {
-	if !c.Org.Organization.IsOwnedBy(c.User.ID) {
+	org := c.Org.Organization
+	if !org.IsOwnedBy(c.User.ID) {
 		c.Error(http.StatusForbidden, "", "given user is not owner of organization")
 		return
 	}
 	team := &db.Team{
-		OrgID:       c.Org.Organization.ID,
+		OrgID:       org.ID,
 		Name:        opt.Name,
 		Description: opt.Description,
 		Authorize:   db.ParseAccessMode(opt.Permission),
@@ -49,4 +51,56 @@ func CreateTeam(c *context.APIContext, opt api.CreateTeamOption) {
 	}
 
 	c.JSON(http.StatusCreated, convert2.ToTeam(team))
+}
+
+func GetTeam(c *context.APIContext) {
+	teamname := c.Params(":team")
+	org := c.Org.Organization
+	team, err := org.GetTeam(teamname)
+	if err != nil {
+		c.NotFoundOrServerError("GetTeamByName", errors.IsTeamNotExist, err)
+		return
+	}
+	c.JSON(200, convert2.ToTeam(team))
+}
+
+func EditTeam(c *context.APIContext, opt api.CreateTeamOption) {
+	teamname := c.Params(":team")
+	org := c.Org.Organization
+	if !org.IsOwnedBy(c.User.ID) {
+		c.Error(http.StatusForbidden, "", "given user is not owner of organization")
+		return
+	}
+	oldteam, err := org.GetTeam(teamname)
+	if err != nil {
+		c.NotFoundOrServerError("EditTeamByName", errors.IsTeamNotExist, err)
+		return
+	}
+	team := &db.Team{
+		ID:          oldteam.ID,
+		OrgID:       org.ID,
+		Name:        opt.Name,
+		Description: opt.Description,
+		Authorize:   db.ParseAccessMode(opt.Permission),
+	}
+	if err := db.UpdateTeam(team, oldteam.Authorize != team.Authorize); err != nil {
+		c.NotFoundOrServerError("EditTeamByName", errors.IsTeamNotExist, err)
+		return
+	}
+	c.JSON(http.StatusCreated, convert2.ToTeam(team))
+}
+
+func DeleteTeam(c *context.APIContext) {
+	teamname := c.Params(":team")
+	org := c.Org.Organization
+	team, err := org.GetTeam(teamname)
+	if err != nil {
+		c.NotFoundOrServerError("DeleteTeamByName", errors.IsTeamNotExist, err)
+		return
+	}
+	if err := db.DeleteTeam(team); err != nil {
+		c.NotFoundOrServerError("DeleteTeamByName", errors.IsTeamNotExist, err)
+		return
+	}
+	c.NoContent()
 }


### PR DESCRIPTION
Grants the ability for members of the Owner team of an Organisation to Create, Edit, and Delete teams.

The standard Owners team cannot be deleted, renamed, or have its permissions changed.  Attempting to edit the Owners team (other than to change the description) does not result in an error.
Attempting to delete the Owners team, returns `Method Not Allowed`.