### PR TITLE
Get DOI badge from tag

### DIFF
--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -97,8 +97,9 @@ func readDataciteFile(entry *git.TreeEntry, c *context.Context) {
 	doi := calcRepoDOI(c, setting.DOI.Base)
 	//ddata, err := ginDoi.GDoiMData(doi, "https://api.datacite.org/works/") //todo configure URL?
 
-	c.Data["DOIReg"] = libgin.IsRegisteredDOI(doi)
-	c.Data["DOI"] = doi
+	if libgin.IsRegisteredDOI(doi) {
+		c.Data["DOI"] = doi
+	}
 }
 
 // calcRepoDOI calculates the theoretical DOI for a repository. If the repository

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -42,7 +42,7 @@
 									</a>
 								</div>
 							{{end}}
-							{{if not $.DOIReg}}
+							{{if not $.DOI}}
 								{{if and (and $.HasDatacite $.IsRepositoryAdmin) (not .IsPrivate)}}
 								<div class="ui labeled button" tabindex="0">
 									<a class="ui basic button"


### PR DESCRIPTION
We're changing the way the DOI badge is determined.  This is a transitional state, so if the new logic fails, it also falls back to the old way so badges should still work as they did until we're finished with the transition.

The logic for getting the badge is as follows:
- if the repository belongs to the DOI user and has a tag that matches the DOI prefix, the DOI is the tag.
- if the repo is forked by the DOI user, check the DOI fork for the tag as above.
- (fallback) if the repo is forked by the DOI user and the fork doesn't have a tag, the DOI is the (old-style) calculated DOI, based on the hash of the repository path.
- An empty string is returned if it is not not forked by the DOI user.

Errors during the fork checking are logged and end the function (returning empty string).
Errors during the tag checking are logged but don't interrupt the function, instead the old-style calculated DOI is returned.

We will soon tag all DOI forks of registered repositories with their DOI.  So far one of them has multiple DOIs, in which case the tag name of the most recent tagged commit (based on commit date) is used.  In the future, we will also be instructing users to tag their repositories (still trying to figure out how to make this straightforward for users, most likely by sending them a URL with the encoded data), but this isn't checked since we don't want to rely on them to have this for the badge and we probably can't expect all the owners of already registered repositories to do it.