### PR TITLE
Repository page header redesign

### DIFF
--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -98,6 +98,45 @@ func readDataciteFile(entry *git.TreeEntry, c *context.Context) {
 	if doi := getRepoDOI(c); doi != "" && libgin.IsRegisteredDOI(doi) {
 		c.Data["DOI"] = doi
 	}
+
+	c.Data["IsDOIReady"] = isDOIReady(c)
+}
+
+// True if repository is not Private, is not registered, or is registered and
+// has changes.
+func isDOIReady(c *context.Context) bool {
+	dbrepo := c.Repo.Repository
+	gitrepo := c.Repo.GitRepo
+
+	headIsRegistered := func() bool {
+		currentDOI, ok := c.Data["DOI"]
+		if !ok {
+			return false
+		}
+
+		headBranch, err := gitrepo.GetHEADBranch()
+		if err != nil {
+			log.Error(2, "Failed to get HEAD branch for repo at %q: %v", gitrepo.Path, err)
+			return false
+		}
+
+		headCommit, err := gitrepo.GetBranchCommitID(headBranch.Name)
+		if err != nil {
+			log.Error(2, "Failed to get commit ID of branch %q for repo at %q: %v", headBranch.Name, gitrepo.Path, err)
+		}
+
+		// if current valid and registered DOI matches the HEAD commit, can't
+		// register again
+		doiCommit, err := gitrepo.GetTagCommitID(currentDOI.(string))
+		if err != nil {
+			log.Error(2, "Failed to get commit ID of tag %q for repo at %q: %v", currentDOI, gitrepo.Path, err)
+		}
+
+		log.Trace("%s ?= %s", headCommit, doiCommit)
+		return headCommit == doiCommit
+	}()
+
+	return !dbrepo.IsPrivate && !headIsRegistered
 }
 
 // getRepoDOI returns the DOI for the repository based on the following rules:

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -43,8 +43,7 @@
 								</div>
 							</form>
 							{{if .CanBeForked}}
-							<div class="ui labeled button" tabindex="0"
-									 data-tooltip="Please note: annexed file content will not be forked" data-position="bottom center">
+							<div class="ui labeled button" tabindex="0" data-tooltip="Please note: annexed file content will not be forked" data-position="bottom center">
 									<a class="ui basic button {{if eq .OwnerID $.LoggedUserID}}poping up{{end}}" href="{{AppSubURL}}/repo/fork/{{.ID}}">
 										<i class="octicon octicon-repo-forked"></i>{{$.i18n.Tr "repo.fork"}}
 									</a>
@@ -53,76 +52,6 @@
 									</a>
 								</div>
 							{{end}}
-							{{if not $.DOI}}
-								{{if and (and $.HasDatacite $.IsRepositoryAdmin) (not .IsPrivate)}}
-								<div class="ui labeled button" tabindex="0">
-									<a class="ui basic button"
-										 href="/{{.Owner.Name}}/{{.Name}}/doi">
-										<i class="octicon octicon-squirrel"></i> DOIfy
-									</a>
-								</div>
-								{{else}}
-								{{if and $.IsRepositoryAdmin $.CommitsCount}}
-								<div class="ui labeled button	" tabindex="0">
-									<a class="ui basic button"
-										 data-tooltip="Your repository does not fulfill all requirements for a doi yet. Click to get instructions."
-										 data-position="bottom center"
-										 href="/G-Node/Info/wiki/DOI">
-										<i class="octicon octicon-squirrel"></i> DOIfy
-									</a>
-									<a class="ui basic label" href="{{$.RepoLink}}/_add/{{EscapePound $.BranchName}}/datacite.yml"
-										data-tooltip="Add Doifile"
-										data-position="bottom center">
-										<i class="octicon octicon-file"></i>
-									</a>
-								</div>
-								{{end}}
-								{{end}}
-							{{end}}
-						</div>
-					{{end}}
-				</div>
-			</div><!-- end column -->
-		</div><!-- end grid -->
-	</div><div class="ui container"><!-- start container -->
-		<div class="ui vertically padded grid head"><!-- start grid -->
-			<div class="column"><!-- start column -->
-				<div class="ui header">
-					{{if not $.IsGuest}}
-						<div class="ui right">
-							<form class="display inline" action="{{$.RepoLink}}/action/{{if $.IsWatchingRepo}}un{{end}}watch?redirect_to={{$.Link}}" method="POST">
-								{{$.CSRFTokenHTML}}
-							</form>
-								{{if and (and $.HasDatacite $.IsRepositoryAdmin) (not .IsPrivate)}}
-								<div class="ui labeled button" tabindex="0">
-									<a class="ui basic button"
-										 href="/{{.Owner.Name}}/{{.Name}}/doi">
-										<i class="octicon octicon-squirrel"></i> DOIfy
-									</a>
-								</div>
-								{{else}}
-								{{if and $.IsRepositoryAdmin $.CommitsCount}}
-								<div class="ui labeled button	" tabindex="0">
-									<a class="ui basic button"
-										 data-tooltip="Your repository does not fulfill all requirements for a doi yet. Click to get instructions."
-										 data-position="bottom center"
-										 href="/G-Node/Info/wiki/DOI">
-										<i class="octicon octicon-squirrel"></i> DOIfy
-									</a>
-									<a class="ui basic label" href="{{$.RepoLink}}/_add/{{EscapePound $.BranchName}}/datacite.yml"
-										data-tooltip="Add Doifile"
-										data-position="bottom center">
-										<i class="octicon octicon-file"></i>
-									</a>
-								</div>
-								{{end}}
-								{{end}}
-								<div class="nobg ui image label">
-									<a href="https://doi.org/{{$.DOI}}">
-										<div class="gin doi">DOI</div>
-									</a>
-									<div class="gin doinr">{{$.DOI}}</div>
-								</div>
 						</div>
 					{{end}}
 				</div>
@@ -130,6 +59,7 @@
 		</div><!-- end grid -->
 	</div><!-- end container -->
 {{end}}
+{{template "repo/header_gin" .}}
 {{if not .IsDiffCompare}}
 	<div class="ui tabs container">
 		<div class="ui tabular menu navbar">

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -67,14 +67,51 @@
 								</div>
 								{{end}}
 								{{end}}
-							{{else}}
-										<div class="nobg ui image label">
-											<a href="https://doi.org/{{$.DOI}}">
-												<div class="gin doi">DOI</div>
-											</a>
-												<div class="gin doinr">{{$.DOI}}</div>
-										</div>
 							{{end}}
+						</div>
+					{{end}}
+				</div>
+			</div><!-- end column -->
+		</div><!-- end grid -->
+	</div><div class="ui container"><!-- start container -->
+		<div class="ui vertically padded grid head"><!-- start grid -->
+			<div class="column"><!-- start column -->
+				<div class="ui header">
+					{{if not $.IsGuest}}
+						<div class="ui right">
+							<form class="display inline" action="{{$.RepoLink}}/action/{{if $.IsWatchingRepo}}un{{end}}watch?redirect_to={{$.Link}}" method="POST">
+								{{$.CSRFTokenHTML}}
+							</form>
+								{{if and (and $.HasDatacite $.IsRepositoryAdmin) (not .IsPrivate)}}
+								<div class="ui labeled button" tabindex="0">
+									<a class="ui basic button"
+										 href="/{{.Owner.Name}}/{{.Name}}/doi">
+										<i class="octicon octicon-squirrel"></i> DOIfy
+									</a>
+								</div>
+								{{else}}
+								{{if and $.IsRepositoryAdmin $.CommitsCount}}
+								<div class="ui labeled button	" tabindex="0">
+									<a class="ui basic button"
+										 data-tooltip="Your repository does not fulfill all requirements for a doi yet. Click to get instructions."
+										 data-position="bottom center"
+										 href="/G-Node/Info/wiki/DOI">
+										<i class="octicon octicon-squirrel"></i> DOIfy
+									</a>
+									<a class="ui basic label" href="{{$.RepoLink}}/_add/{{EscapePound $.BranchName}}/datacite.yml"
+										data-tooltip="Add Doifile"
+										data-position="bottom center">
+										<i class="octicon octicon-file"></i>
+									</a>
+								</div>
+								{{end}}
+								{{end}}
+								<div class="nobg ui image label">
+									<a href="https://doi.org/{{$.DOI}}">
+										<div class="gin doi">DOI</div>
+									</a>
+									<div class="gin doinr">{{$.DOI}}</div>
+								</div>
 						</div>
 					{{end}}
 				</div>

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -31,6 +31,17 @@
 									</a>
 								</div>
 							</form>
+							<form class="display inline" action="{{$.RepoLink}}/action/{{if $.IsStaringRepo}}un{{end}}star?redirect_to={{$.Link}}" method="POST">
+								{{$.CSRFTokenHTML}}
+								<div class="ui labeled button" tabindex="0">
+									<button class="ui basic button">
+										<i class="star{{if not $.IsStaringRepo}} outline{{end}} icon"></i>{{if $.IsStaringRepo}}{{$.i18n.Tr "repo.unstar"}}{{else}}{{$.i18n.Tr "repo.star"}}{{end}}
+									</button>
+									<a class="ui basic label" href="{{.Link}}/stars">
+										{{.NumStars}}
+									</a>
+								</div>
+							</form>
 							{{if .CanBeForked}}
 							<div class="ui labeled button" tabindex="0"
 									 data-tooltip="Please note: annexed file content will not be forked" data-position="bottom center">

--- a/templates/repo/header_gin.tmpl
+++ b/templates/repo/header_gin.tmpl
@@ -1,0 +1,37 @@
+<div class="ui container"><!-- start container -->
+	<div class="ui vertically padded grid head"><!-- start grid -->
+		<div class="column"><!-- start column -->
+			<div class="ui header">
+				{{if not $.IsGuest}}
+					<div class="ui right">
+						{{if $.IsRepositoryAdmin}}
+							{{if $.IsDOIReady}} {{/* Ready to (re)register: Show button */}}
+							<div class="ui labeled button" tabindex="0">
+								<a class="ui basic button" href="/{{.Owner.Name}}/{{.Name}}/doi"><i class="octicon octicon-squirrel"></i>DOIfy</a>
+							</div>
+							{{else if not $.DOI}} {{/*Link to registration instructions*/}}
+								<div class="ui labeled button	" tabindex="0">
+									<a class="ui basic button" data-tooltip="Your repository does not fulfill all requirements for a doi yet. Click to get instructions." data-position="bottom center" href="/G-Node/Info/wiki/DOI">
+										<i class="octicon octicon-squirrel"></i> DOIfy
+									</a>
+									<a class="ui basic label" href="{{$.RepoLink}}/_add/{{EscapePound $.BranchName}}/datacite.yml" data-tooltip="Add Doifile" data-position="bottom center">
+										<i class="octicon octicon-file"></i>
+									</a>
+								</div>
+							{{end}} {{/* End registration button */}}
+						{{end}} {{/* Admin section */}}
+							
+						{{if $.DOI}} {{/* Registered repo: Show DOI badge */}}
+							<div class="nobg ui image label">
+								<a href="https://doi.org/{{$.DOI}}">
+									<div class="gin doi">DOI</div>
+								</a>
+								<div class="gin doinr">{{$.DOI}}</div>
+							</div>
+						{{end}} {{/* End DOI badge */}}
+					</div>
+				{{end}}
+			</div>
+		</div>
+	</div>
+</div>

--- a/templates/repo/header_gin.tmpl
+++ b/templates/repo/header_gin.tmpl
@@ -7,7 +7,7 @@
 						{{if $.IsRepositoryAdmin}}
 							{{if $.IsDOIReady}} {{/* Ready to (re)register: Show button */}}
 							<div class="ui labeled button" tabindex="0">
-								<a class="ui basic button" href="/{{.Owner.Name}}/{{.Name}}/doi"><i class="octicon octicon-squirrel"></i> Request DOI</a>
+								<a class="ui basic button" href="/{{.Repository.Owner.Name}}/{{.Repository.Name}}/doi"><i class="octicon octicon-squirrel"></i> Request DOI</a>
 							</div>
 							{{else if not $.DOI}} {{/*Link to registration instructions*/}}
 								<div class="ui labeled button	" tabindex="0">

--- a/templates/repo/header_gin.tmpl
+++ b/templates/repo/header_gin.tmpl
@@ -4,7 +4,7 @@
 			<div class="ui header">
 				{{if not $.IsGuest}}
 					<div class="ui right">
-						{{if $.IsRepositoryAdmin}}
+						{{if and $.IsRepositoryAdmin .PageIsRepoHome}}
 							{{if $.IsDOIReady}} {{/* Ready to (re)register: Show button */}}
 							<div class="ui labeled button" tabindex="0">
 								<a class="ui basic button" href="/{{.Repository.Owner.Name}}/{{.Repository.Name}}/doi"><i class="octicon octicon-squirrel"></i> Request DOI</a>

--- a/templates/repo/header_gin.tmpl
+++ b/templates/repo/header_gin.tmpl
@@ -7,14 +7,14 @@
 						{{if $.IsRepositoryAdmin}}
 							{{if $.IsDOIReady}} {{/* Ready to (re)register: Show button */}}
 							<div class="ui labeled button" tabindex="0">
-								<a class="ui basic button" href="/{{.Owner.Name}}/{{.Name}}/doi"><i class="octicon octicon-squirrel"></i>DOIfy</a>
+								<a class="ui basic button" href="/{{.Owner.Name}}/{{.Name}}/doi"><i class="octicon octicon-squirrel"></i> Request DOI</a>
 							</div>
 							{{else if not $.DOI}} {{/*Link to registration instructions*/}}
 								<div class="ui labeled button	" tabindex="0">
-									<a class="ui basic button" data-tooltip="Your repository does not fulfill all requirements for a doi yet. Click to get instructions." data-position="bottom center" href="/G-Node/Info/wiki/DOI">
-										<i class="octicon octicon-squirrel"></i> DOIfy
+									<a class="ui basic button" data-tooltip="Your repository does not fulfill all requirements for a DOI yet. Click to get instructions." data-position="bottom center" href="/G-Node/Info/wiki/DOI">
+										<i class="octicon octicon-squirrel"></i> How to publish
 									</a>
-									<a class="ui basic label" href="{{$.RepoLink}}/_add/{{EscapePound $.BranchName}}/datacite.yml" data-tooltip="Add Doifile" data-position="bottom center">
+									<a class="ui basic label" href="{{$.RepoLink}}/_add/{{EscapePound $.BranchName}}/datacite.yml" data-tooltip="Add datacite file" data-position="bottom center">
 										<i class="octicon octicon-file"></i>
 									</a>
 								</div>

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -77,37 +77,33 @@
 								SSH
 							</button>
 						{{end}}
-						<input id="repo-clone-url" value="{{if not $.DisableHTTP}}{{$.CloneLink.HTTPS}}{{else}}{{$.CloneLink.SSH}}{{end}}" readonly >
+						<input id="repo-clone-url" value="{{if not $.DisableHTTP}}{{$.CloneLink.HTTPS}}{{else}}{{$.CloneLink.SSH}}{{end}}" readonly>
 						<button class="ui basic icon button poping up clipboard" id="clipboard-btn" data-original="{{.i18n.Tr "repo.copy_link"}}" data-success="{{.i18n.Tr "repo.copy_link_success"}}" data-error="{{.i18n.Tr "repo.copy_link_error"}}" data-content="{{.i18n.Tr "repo.copy_link"}}" data-variation="inverted tiny" data-clipboard-target="#repo-clone-url">
 							<i class="octicon octicon-clippy"></i>
 						</button>
 						<div id="download-repo-button" class="ui basic icon button poping up" data-original="Archives">
-						<i class="download icon"></i>
-						</div>
-
-						<!-- Download modal -->
-						<div id="download_modal" class="ui modal warning">
-							<i class="close icon"></i>
-							<div class="content">
-								<div class="ui header">So you want to download data without special tooling (e.g. git, git-annex or GIN)?</div>
-								<p>Here is what you can do:</p>
-								<p>Download the small files and the file structure as an archive (.zip or .tar.gz). Annexed files (by default, files larger than 10 MB) will be
-								included as pointer files (stubs) but the data will not be included. To get the content of the big files you need to download them individually
-								from this web page.</p>
-								<p>Download the small files as a GIN archive (.gin.zip). This includes all the git information,
-								including the history of the repository and the possibility to download the content of large files using git annex or the GIN client.</p>
-							</div>
-							<div class="actions">
-								<a class="ui positive button" href="{{$.RepoLink}}/archive/{{EscapePound $.BranchName}}.zip"><i class="octicon octicon-file-zip"></i> Download zip</a>
-								<a class="ui positive button" href="{{$.RepoLink}}/archive/{{EscapePound $.BranchName}}.tar.gz"><i class="octicon octicon-file-zip"></i> Download tar.gz</a>
-								<a class="ui positive button" href="{{$.RepoLink}}/archive/{{EscapePound $.BranchName}}.gin.zip"><i
-									class="octicon octicon-file-zip"></i> Download GIN archive</a>
+							<i class="download icon"></i>
+							<!-- Download modal -->
+							<div id="download_modal" class="ui modal warning">
+								<i class="close icon"></i>
+								<div class="content">
+									<div class="ui header">Download repository archive</div>
+									<p>To download data without special tooling (e.g. git, git-annex or GIN) you can:</p>
+									<p>Download the small files and the file structure as an archive (.zip or .tar.gz). Annexed files (by default, files larger than 10 MB) will be
+									included as pointer files (stubs) but the data will not be included. To get the content of the big files you need to download them individually
+									from this web page.</p>
+									<p>Download the small files as a GIN archive (.gin.zip). This includes all the git information,
+									including the history of the repository and the possibility to download the content of large files using git annex or the GIN client.</p>
+								</div>
+								<div class="actions">
+									<a class="ui positive button" href="{{$.RepoLink}}/archive/{{EscapePound $.BranchName}}.zip"><i class="octicon octicon-file-zip"></i> Download zip</a>
+									<a class="ui positive button" href="{{$.RepoLink}}/archive/{{EscapePound $.BranchName}}.tar.gz"><i class="octicon octicon-file-zip"></i> Download tar.gz</a>
+									<a class="ui positive button" href="{{$.RepoLink}}/archive/{{EscapePound $.BranchName}}.gin.zip"><i class="octicon octicon-file-zip"></i> Download GIN archive</a>
+								</div>
 							</div>
 						</div>
-
-
+					</div>
 				{{end}}
-				</div>
 			</div>
 		</div>
 		{{if .IsViewFile}}

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -26,14 +26,9 @@
 			{{if .PullRequestCtx.Allowed}}
 				<div class="fitted item" data-tooltip="Please note: annexed file content will not be part of a pull request">
 					<a href="{{.BaseRepo.Link}}/compare/{{EscapePound .BaseRepo.DefaultBranch}}...{{EscapePound .PullRequestCtx.HeadInfo}}">
-						<button class="ui green small button"><i class="octicon octicon-git-compare"></i>Pull request</button>
+						<button class="ui green small button"><i class="octicon octicon-git-compare"></i></button>
 					</a>
 				</div>
-				{{else if or .IsRepositoryWriter .HasForked}}
-					<div class="fitted item"
-							data-tooltip="Pull requests have been disabled for this repository" data-position="top center">
-							<button class="ui disabled small button"><i class="octicon octicon-git-compare"></i></button>
-					</div>
 			{{end}}
 			{{template "repo/branch_dropdown" .}}
 			<div class="fitted item">
@@ -53,7 +48,6 @@
 				</div>
 			</div>
 			<div class="right fitted item">
-				<div class="ui action small input" id="clone-panel">
 				{{if .Repository.CanEnableEditor}}
 					<div id="file-buttons" class="ui tiny blue buttons">
 						{{if .CanAddFile}}
@@ -70,14 +64,10 @@
 				{{end}}
 
 				<!-- Only show clone panel in repository home page -->
-				{{ $n := len .TreeNames}}
-				{{ $l := Subtract $n 1}}
 				{{if eq $n 0}}
-
-						<button class="ui basic clone button" id="repo-clone-gin" data-link="{{.CloneLink.Gin}}">
-							GIN
-						</button>
-						{{if and (not $.DisableHTTP) $.ShowHTTP}}
+					<div class="ui action small input" id="clone-panel">
+						<button class="ui basic clone button" id="repo-clone-gin" data-link="{{.CloneLink.Gin}}">GIN</button>
+						{{if not $.DisableHTTP}}
 							<button class="ui basic clone button" id="repo-clone-https" data-link="{{.CloneLink.HTTPS}}">
 								{{if UseHTTPS}}HTTPS{{else}}HTTP{{end}}
 							</button>


### PR DESCRIPTION
The header of the repository page where the buttons (Fork, Watch) appear has been redesigned.  The biggest change is that the original design from upstream is preserved and the "Star" function is back.  The DOI-related buttons and badge now appear on a separate line below the original buttons.  Have a look at the comparison screenshots below:

### Registered repository
Current (original repo and DOI fork)
![image](https://user-images.githubusercontent.com/2369197/82235114-9aa2da80-9932-11ea-99bd-5366ddea82d1.png)

![image](https://user-images.githubusercontent.com/2369197/82235088-9080dc00-9932-11ea-9dcd-6e00b0fe8867.png)

New
![image](https://user-images.githubusercontent.com/2369197/82235198-b4442200-9932-11ea-9457-565a3d858d26.png)
![image](https://user-images.githubusercontent.com/2369197/82235236-bdcd8a00-9932-11ea-9dc4-a089325cb6c1.png)

### Unregistered repository (owner view)
Current
![image](https://user-images.githubusercontent.com/2369197/82235568-2583d500-9933-11ea-9709-10ccac56b16a.png)

New
![image](https://user-images.githubusercontent.com/2369197/82235383-eb1a3800-9932-11ea-8b9c-cdd133eff43a.png)

Note that the old **DOIfy** button, which in this case links to the help page on how to prepare a repository for publication, is now labelled **How to publish**.

### Unregistered repository (non owner view)
For non-owners, the second row doesn't appear, which is the same as now but with the star button included.
![image](https://user-images.githubusercontent.com/2369197/82235775-78f62300-9933-11ea-9745-f0c2b42a3eed.png)


### Ready to register (owner view)
Current
![image](https://user-images.githubusercontent.com/2369197/82236055-d9856000-9933-11ea-810e-3ca77588029e.png)

New
![image](https://user-images.githubusercontent.com/2369197/82236108-ed30c680-9933-11ea-94ee-ccecb4a94744.png)

When a repository is ready to register, the button is labeled **Request DOI**.

### NEW STATE: Registered but has changes and is ready to re-register
![image](https://user-images.githubusercontent.com/2369197/82236231-194c4780-9934-11ea-806d-90dac53457ba.png)

When a repository is already registered, but the most recently registered DOI commit with a valid tag is not the HEAD commit, both the badge and the button appear, so the owner can register a new version of the same dataset.

For the **Request DOI** to reappear on a registered repository, the repo must remain public, have a datacite.yml file, and the head of the default (master) branch must not be tagged with the valid current DOI.