### PR TITLE
Header fix: Edit DataCite file and bare repository handling

### DIFF
--- a/internal/context/context_gin.go
+++ b/internal/context/context_gin.go
@@ -75,9 +75,9 @@ func getRepoDOI(c *Context) string {
 					latestTag = tagName
 					latestTime = commitTime
 				}
-				return latestTag
 			}
 		}
+		return latestTag
 	} else {
 		// this shouldn't happen even if there are no tags
 		// log the error, but fall back to the old method anyway

--- a/internal/context/context_gin.go
+++ b/internal/context/context_gin.go
@@ -93,3 +93,16 @@ func getRepoDOI(c *Context) string {
 	uuid := libgin.RepoPathToUUID(repoPath)
 	return doiBase + uuid[:6]
 }
+
+// hasDataCite returns 'true' if a repository includes a file called
+// 'datacite.yml' in its root.  No checks are made to determine if the file is
+// valid.  If any error occurs, for example due to an uninitialised repository
+// or missing repository root, it returns 'false' without error.
+func hasDataCite(c *Context) bool {
+	commit, err := c.Repo.GitRepo.GetBranchCommit(c.Repo.Repository.DefaultBranch)
+	if err != nil {
+		return false
+	}
+	_, err = commit.GetBlobByPath("./datacite.yml")
+	return err == nil
+}

--- a/internal/context/context_gin.go
+++ b/internal/context/context_gin.go
@@ -134,6 +134,7 @@ func isDOIReady(c *Context) bool {
 		headCommit, err := gitrepo.GetBranchCommitID(headBranch.Name)
 		if err != nil {
 			log.Error(2, "Failed to get commit ID of branch %q for repo at %q: %v", headBranch.Name, gitrepo.Path, err)
+			return false
 		}
 
 		// if current valid and registered DOI matches the HEAD commit, can't
@@ -141,6 +142,7 @@ func isDOIReady(c *Context) bool {
 		doiCommit, err := gitrepo.GetTagCommitID(currentDOI.(string))
 		if err != nil {
 			log.Error(2, "Failed to get commit ID of tag %q for repo at %q: %v", currentDOI, gitrepo.Path, err)
+			return false
 		}
 
 		log.Trace("%s ?= %s", headCommit, doiCommit)

--- a/internal/context/repo.go
+++ b/internal/context/repo.go
@@ -270,6 +270,8 @@ func RepoAssignment(pages ...bool) macaron.Handler {
 
 		c.Data["IsGuest"] = !c.Repo.HasAccess()
 
+		c.Data["HasDataCite"] = hasDataCite(c)
+
 		if doi := getRepoDOI(c); doi != "" && libgin.IsRegisteredDOI(doi) {
 			c.Data["DOI"] = doi
 		}

--- a/internal/context/repo.go
+++ b/internal/context/repo.go
@@ -270,7 +270,11 @@ func RepoAssignment(pages ...bool) macaron.Handler {
 
 		c.Data["IsGuest"] = !c.Repo.HasAccess()
 
-		c.Data["HasDataCite"] = hasDataCite(c)
+		hasDC := hasDataCite(c)
+		c.Data["HasDataCite"] = hasDC
+		if hasDC {
+			c.Data["IsDOIReady"] = isDOIReady(c)
+		}
 
 		if doi := getRepoDOI(c); doi != "" && libgin.IsRegisteredDOI(doi) {
 			c.Data["DOI"] = doi

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -73,67 +73,34 @@ func serveAnnexedKey(ctx *context.Context, name string, contentPath string) erro
 	return err
 }
 
-func readDataciteFile(entry *git.Blob, c *context.Context) {
-	log.Trace("Found datacite.yml file")
-	c.Data["HasDataCite"] = true
+func readDataciteFile(c *context.Context) {
+	log.Trace("Reading datacite.yml file")
+	entry, err := c.Repo.Commit.GetBlobByPath("/datacite.yml")
+	if err != nil || entry == nil {
+		log.Error(2, "datacite.yml blob could not be retrieved: %v", err)
+		c.Data["HasDataCite"] = false
+		return
+	}
 	doiData, err := entry.Data()
 	if err != nil {
 		log.Error(2, "datacite.yml blob could not be read: %v", err)
+		c.Data["HasDataCite"] = false
 		return
 	}
 	buf, err := ioutil.ReadAll(doiData)
 	if err != nil {
 		log.Error(2, "datacite.yml data could not be read: %v", err)
+		c.Data["HasDataCite"] = false
 		return
 	}
 	doiInfo := libgin.DOIRegInfo{}
 	err = yaml.Unmarshal(buf, &doiInfo)
 	if err != nil {
 		log.Error(2, "datacite.yml data could not be unmarshalled: %v", err)
+		c.Data["HasDataCite"] = false
 		return
 	}
 	c.Data["DOIInfo"] = &doiInfo
-	c.Data["IsDOIReady"] = isDOIReady(c)
-}
-
-// True if repository is not Private, is not registered, or is registered and
-// has changes.
-func isDOIReady(c *context.Context) bool {
-	if hasDC, ok := c.Data["HasDataCite"]; !ok || !hasDC.(bool) {
-		return false
-	}
-	dbrepo := c.Repo.Repository
-	gitrepo := c.Repo.GitRepo
-
-	headIsRegistered := func() bool {
-		currentDOI, ok := c.Data["DOI"]
-		if !ok {
-			return false
-		}
-
-		headBranch, err := gitrepo.GetHEADBranch()
-		if err != nil {
-			log.Error(2, "Failed to get HEAD branch for repo at %q: %v", gitrepo.Path, err)
-			return false
-		}
-
-		headCommit, err := gitrepo.GetBranchCommitID(headBranch.Name)
-		if err != nil {
-			log.Error(2, "Failed to get commit ID of branch %q for repo at %q: %v", headBranch.Name, gitrepo.Path, err)
-		}
-
-		// if current valid and registered DOI matches the HEAD commit, can't
-		// register again
-		doiCommit, err := gitrepo.GetTagCommitID(currentDOI.(string))
-		if err != nil {
-			log.Error(2, "Failed to get commit ID of tag %q for repo at %q: %v", currentDOI, gitrepo.Path, err)
-		}
-
-		log.Trace("%s ?= %s", headCommit, doiCommit)
-		return headCommit == doiCommit
-	}()
-
-	return !dbrepo.IsPrivate && !headIsRegistered
 }
 
 // resolveAnnexedContent takes a buffer with the contents of a git-annex

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -73,10 +73,10 @@ func serveAnnexedKey(ctx *context.Context, name string, contentPath string) erro
 	return err
 }
 
-func readDataciteFile(entry *git.TreeEntry, c *context.Context) {
+func readDataciteFile(entry *git.Blob, c *context.Context) {
 	log.Trace("Found datacite.yml file")
-	c.Data["HasDatacite"] = true
-	doiData, err := entry.Blob().Data()
+	c.Data["HasDataCite"] = true
+	doiData, err := entry.Data()
 	if err != nil {
 		log.Error(2, "datacite.yml blob could not be read: %v", err)
 		return
@@ -99,7 +99,7 @@ func readDataciteFile(entry *git.TreeEntry, c *context.Context) {
 // True if repository is not Private, is not registered, or is registered and
 // has changes.
 func isDOIReady(c *context.Context) bool {
-	if hasDC, ok := c.Data["HasDatacite"]; !ok || !hasDC.(bool) {
+	if hasDC, ok := c.Data["HasDataCite"]; !ok || !hasDC.(bool) {
 		return false
 	}
 	dbrepo := c.Repo.Repository

--- a/internal/route/repo/view.go
+++ b/internal/route/repo/view.go
@@ -55,9 +55,7 @@ func renderDirectory(c *context.Context, treeLink string) {
 		return
 	}
 	if c.Data["HasDataCite"].(bool) {
-		if entry, err := tree.GetBlobByPath("datacite.yml"); err != nil {
-			readDataciteFile(entry, c)
-		}
+		readDataciteFile(c)
 	}
 	var readmeFile *git.Blob
 	for _, entry := range entries {

--- a/internal/route/repo/view.go
+++ b/internal/route/repo/view.go
@@ -54,14 +54,12 @@ func renderDirectory(c *context.Context, treeLink string) {
 		c.ServerError("GetCommitsInfoWithCustomConcurrency", err)
 		return
 	}
-	c.Data["HasDatacite"] = false
-	var readmeFile *git.Blob
-	for _, entry := range entries {
-		if !entry.IsDir() && entry.Name() == "datacite.yml" {
+	if c.Data["HasDataCite"].(bool) {
+		if entry, err := tree.GetBlobByPath("datacite.yml"); err != nil {
 			readDataciteFile(entry, c)
-			break
 		}
 	}
+	var readmeFile *git.Blob
 	for _, entry := range entries {
 		if entry.IsDir() || !markup.IsReadmeFile(entry.Name()) {
 			continue

--- a/templates/repo/header_gin.tmpl
+++ b/templates/repo/header_gin.tmpl
@@ -1,4 +1,5 @@
-{{if or $.DOI $.IsRepositoryAdmin}} {{/* Show DOI buttons or badge */}}
+{{if not $.IsBareRepo}}
+	{{if or $.DOI $.IsRepositoryAdmin}} {{/* Show DOI buttons or badge */}}
 					{{if $.IsRepositoryAdmin}}
 						{{if $.IsDOIReady}} {{/* Ready to (re)register: Show button */}}
 							<a class="ui basic button" href="/{{.Repository.Owner.Name}}/{{.Repository.Name}}/doi"><i class="octicon octicon-squirrel"></i> Request {{if $.DOI}}New{{end}} DOI</a>
@@ -30,4 +31,5 @@
 			<div class="column"><!-- start column -->
 				<div class="ui header">
 					<div class="ui right">
+	{{end}}
 {{end}}

--- a/templates/repo/header_gin.tmpl
+++ b/templates/repo/header_gin.tmpl
@@ -4,7 +4,11 @@
 							<a class="ui basic button" href="/{{.Repository.Owner.Name}}/{{.Repository.Name}}/doi"><i class="octicon octicon-squirrel"></i> Request {{if $.DOI}}New{{end}} DOI</a>
 						{{else if not $.DOI}} {{/*Link to registration instructions*/}}
 							<a class="ui basic button" data-tooltip="Your repository does not fulfill all requirements for a DOI yet. Click to get instructions." data-position="bottom center" href="/G-Node/Info/wiki/DOI"><i class="octicon octicon-squirrel"></i> How to publish</a>
-							<a class="ui basic button" href="{{$.RepoLink}}/_add/{{EscapePound $.BranchName}}/datacite.yml" data-tooltip="Add datacite file" data-position="bottom center"><i class="octicon octicon-file">Add DataCite file</i></a>
+							{{if $.HasDataCite}}
+								<a class="ui basic button" href="{{$.RepoLink}}/_edit/{{EscapePound $.BranchName}}/datacite.yml" data-tooltip="Add datacite file" data-position="bottom center"><i class="octicon octicon-file">Edit DataCite file</i></a>
+							{{else}}
+								<a class="ui basic button" href="{{$.RepoLink}}/_add/{{EscapePound $.BranchName}}/datacite.yml" data-tooltip="Add datacite file" data-position="bottom center"><i class="octicon octicon-file">Add DataCite file</i></a>
+							{{end}}
 						{{end}} {{/* End registration button */}}
 					{{end}} {{/* Admin section */}}
 					{{if $.DOI}} {{/* Registered repo: Show DOI badge */}}

--- a/templates/repo/header_gin.tmpl
+++ b/templates/repo/header_gin.tmpl
@@ -16,8 +16,8 @@
 						<div class="ui labeled button" tabindex="0">
 							<a href="https://doi.org/{{$.DOI}}">
 								<div class="gin doi">DOI</div>
+								<div class="gin doinr">{{$.DOI}}</div>
 							</a>
-							<div class="gin doinr">{{$.DOI}}</div>
 						</div>
 					{{end}} {{/* End DOI badge */}}
 					{{/* Close original header divs and create second row below for original buttons */}}

--- a/templates/repo/view_list.tmpl
+++ b/templates/repo/view_list.tmpl
@@ -59,6 +59,6 @@
 {{if and .ReadmeExist .IsTextFile}}
 	{{template "repo/view_file" .}}
 {{end}}
-{{if and .HasDatacite .IsTextFile}}
+{{if and .HasDataCite .IsTextFile}}
 	{{template "repo/doifile" .}}
 {{end}}


### PR DESCRIPTION
Was working on a minor change and discovered a nasty bug:
When the repository isn't initialised, trying to determine which buttons to render causes an error.  I hotfixed the template on the live server to avoid further errors, so now it checks if the repository is Bare (which is also true when uninitialised) and if it is, doesn't render any gin-specific header buttons.

The minor change this includes is that the "Add DataCite file" button becomes "Edit DataCite file" when the file already exists and links to the edit page of the existing file instead of trying to add a new one.  Trying to add a new one would cause an error on commit.  This is a pretty old bug that I never noticed.