### PR TITLE
Fix/commit timeout

### DIFF
--- a/internal/db/models_gin.go
+++ b/internal/db/models_gin.go
@@ -71,7 +71,7 @@ func RebuildIndex() error {
 }
 
 func annexUninit(path string) {
-	// walker sets the permission for any file found to 0600, to allow deletion
+	// walker sets the permission for any file found to 0660, to allow deletion
 	var mode os.FileMode
 	walker := func(path string, info os.FileInfo, err error) error {
 		if info == nil {
@@ -102,18 +102,18 @@ func annexSetup(path string) {
 	log.Trace("Running annex add (with filesize filter) in '%s'", path)
 
 	// Initialise annex in case it's a new repository
-	if msg, err := annex.Init(path, "--version=7"); err != nil {
+	if msg, err := annex.Init(path); err != nil {
 		log.Error(2, "Annex init failed: %v (%s)", err, msg)
 		return
 	}
 
-	// Upgrade to v7 in case the directory was here before and wasn't cleaned up properly
+	// Upgrade to v8 in case the directory was here before and wasn't cleaned up properly
 	if msg, err := annex.Upgrade(path); err != nil {
 		log.Error(2, "Annex upgrade failed: %v (%s)", err, msg)
 		return
 	}
 
-	// Enable addunlocked for annex v7
+	// Enable addunlocked for annex v8
 	if msg, err := annex.SetAddUnlocked(path); err != nil {
 		log.Error(2, "Failed to set 'addunlocked' annex option: %v (%s)", err, msg)
 	}

--- a/internal/db/repo_editor.go
+++ b/internal/db/repo_editor.go
@@ -502,8 +502,8 @@ func (repo *Repository) UploadRepoFiles(doer *User, opts UploadRepoFileOptions) 
 	}
 
 	annexSetup(localPath) // Initialise annex and set configuration (with add filter for filesizes)
-	if err = git.AddChanges(localPath, true); err != nil {
-		return fmt.Errorf("git add --all: %v", err)
+	if err = annexAdd(localPath, true); err != nil {
+		return fmt.Errorf("git annex add: %v", err)
 	} else if err = git.CommitChanges(localPath, git.CommitChangesOptions{
 		Committer: doer.NewGitSig(),
 		Message:   opts.Message,
@@ -521,8 +521,8 @@ func (repo *Repository) UploadRepoFiles(doer *User, opts UploadRepoFileOptions) 
 		return fmt.Errorf("git push origin %s: %v", opts.NewBranch, err)
 	}
 
-	if err := annexSync(localPath); err != nil { // Run full annex sync
-		return fmt.Errorf("annex sync %s: %v", localPath, err)
+	if err := annexUpload(localPath, "origin"); err != nil { // Copy new files
+		return fmt.Errorf("annex copy %s: %v", localPath, err)
 	}
 	annexUninit(localPath) // Uninitialise annex to prepare for deletion
 	StartIndexing(*repo)   // Index the new data


### PR DESCRIPTION
This PR makes web uploads a bit faster by using `git annex add` and `git annex copy` to replace `git add` and `git annex sync --content` respectively.

`git annex add` is often faster than `git add`, especially when working on a large number of files.  This is a consequence of how git-annex sets up smudge filters.

`git annex copy` only uploads new files to the remote, as opposed to `git annex sync --content` which also downloads all missing content files.  Before running a `git annex copy` however, we still need to run a `git annex sync` without `--content` so synchronise repository information.

I've tested the change and it makes the upload commits significantly faster.  I'm hoping this will resolve the issue reported on GIN: https://gin.g-node.org/G-Node/Info/issues/32

This PR also makes a small change in the way the git-module functions are used.  We currently have our own fork of the GOGS git-module which includes a few git-annex functions.  I want to get rid of this and move annex-related functions to libgin for both our GOGS and gin-cli.  For now I'm adding these new annex functions here, with calls to the git-module `git.Command()`, which is how git commands are run.  This is the first step to reverting the git-module to upstream.