### PR TITLE
"Do not reply" note in emails

### DIFF
--- a/templates/mail/issue/comment.tmpl
+++ b/templates/mail/issue/comment.tmpl
@@ -10,6 +10,7 @@
 	<p>
 		---
 		<br>
+		<i>Please do not reply to this email. This mailbox is not monitored. Click the link above below to comment on the issue.</i>
 		<a href="{{.Link}}">View it on GIN</a>.
 	</p>
 </body>

--- a/templates/mail/issue/mention.tmpl
+++ b/templates/mail/issue/mention.tmpl
@@ -11,6 +11,7 @@
 	<p>
 		---
 		<br>
+		<i>Please do not reply to this email. This mailbox is not monitored. Click the link above below to comment on the issue.</i>
 		<a href="{{.Link}}">View it on GIN</a>.
 	</p>
 </body>

--- a/templates/mail/notify/collaborator.tmpl
+++ b/templates/mail/notify/collaborator.tmpl
@@ -10,6 +10,7 @@
 	<p>
 		---
 		<br>
+		<i>Please do not reply to this email. This mailbox is not monitored.</i>
 		<a href="{{.Link}}">View it on Gin</a>.
 	</p>
 </body>


### PR DESCRIPTION
Once in a while people respond to notification emails from GIN.  This works on some code forge websites (like GitHub) so we should make it clear that we don't support this and that they shouldn't respond.