### PR TITLE
Footer link fix for PLOS recommendation

### DIFF
--- a/templates/base/footer.tmpl
+++ b/templates/base/footer.tmpl
@@ -31,7 +31,7 @@
 				<span>Registered with: <a href="http://doi.org/10.17616/R3SX9N"><img class="ui mini footericon" src="{{AppSubURL}}/img/re3data_logo.png"/></a>          </span>
 				<span>Recommended by:  
 					<a href="https://www.nature.com/sdata/policies/repositories#neurosci"><img class="ui mini footericon" src="{{AppSubURL}}/img/sdatarecbadge.jpg"/></a>
-					<a href="https://journals.plos.org/plosone/s/data-availability#loc-neuroscience"><img class="ui mini footericon" src="{{AppSubURL}}/img/sm_plos-logo-sm.png"/></a>
+					<a href="https://fairsharing.org/recommendation/PLOS"><img class="ui mini footericon" src="{{AppSubURL}}/img/sm_plos-logo-sm.png"/></a>
 					<a href="https://fairsharing.org/recommendation/eLifeRecommendedRepositoriesandStandards"><img class="ui mini footericon" src="{{AppSubURL}}/img/elife-logo-xs.fd623d00.svg"/></a>
 				</span>
 			</div>


### PR DESCRIPTION
PLOS has moved their recommended repos list to fairsharing.
