### PR TITLE
Add stars to admin panel repo list

### DIFF
--- a/templates/admin/repo/list.tmpl
+++ b/templates/admin/repo/list.tmpl
@@ -35,6 +35,7 @@
 									<td><a href="{{AppSubURL}}/{{.Owner.Name}}/{{.Name}}">{{.Name}}</a></td>
 									<td><i class="fa fa{{if .IsPrivate}}-check{{end}}-square-o"></i></td>
 									<td>{{.NumWatches}}</td>
+									<td>{{.NumStars}}</td>
 									<td>{{.NumIssues}}</td>
 									<td>{{.Size | FileSize}}</td>
 									<td><span title="{{DateFmtLong .Created}}">{{DateFmtShort .Created}}</span></td>


### PR DESCRIPTION
NumStars were removed from the repository list in the admin panel but the table header was never removed which makes the table look broken.
Stars are back now, so bringing back the number.