### PR TITLE
RF: in list of files, link to tree (not commit) for submodules

### DIFF
--- a/templates/repo/view_list.tmpl
+++ b/templates/repo/view_list.tmpl
@@ -9,7 +9,7 @@
 					<img class="ui avatar image img-12" src="{{AvatarLink .LatestCommit.Author.Email}}" />
 					<strong>{{.LatestCommit.Author.Name}}</strong>
 				{{end}}
-				<a rel="nofollow" class="ui sha label" href="{{.RepoLink}}/commit/{{.LatestCommit.ID}}" rel="nofollow">{{ShortSHA1 .LatestCommit.ID.String}}</a>
+				<a rel="nofollow" class="ui sha label" href="{{.RepoLink}}/tree/{{.LatestCommit.ID}}" rel="nofollow">{{ShortSHA1 .LatestCommit.ID.String}}</a>
 				<span class="grey has-emoji">{{RenderCommitMessage false .LatestCommit.Summary .RepoLink $.Repository.ComposeMetas | Str2HTML}}</span>
 			</th>
 			<th class="nine wide">


### PR DESCRIPTION
While navigating files it makes more sense to jump to that specific
state of the tree instead of specific commit diff.  With such trivial
change we should be able to achive that.  In other similar uses of /commit/
I left them as is since there it does makes more sense to jump to diff.

Inspired by @aksoo
