### PR TITLE
fix: prevent annexed files to be edited with WebUI

### DIFF
--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -102,12 +102,14 @@ func readDataciteFile(c *context.Context) {
 // and io.Reader sent in through the caller so that any existing code can use
 // the two variables without modifications.
 // Any errors that occur during processing are stored in the provided context.
-// The FileSize of the annexed content is also saved in the context (c.Data["FileSize"]).
+// The FileSize of the annexed content is also saved in the context (c.Data["FileSize"]),
+// along with a flag indicating that the file is annexed (c.Data["IsAnnexedFile"]).
 func resolveAnnexedContent(c *context.Context, buf []byte) ([]byte, error) {
 	if !tool.IsAnnexedFile(buf) {
 		// not an annex pointer file; return as is
 		return buf, nil
 	}
+	c.Data["IsAnnexedFile"] = true
 	log.Trace("Annexed file requested: Resolving content for %q", bytes.TrimSpace(buf))
 
 	keyparts := strings.Split(strings.TrimSpace(string(buf)), "/")

--- a/internal/route/repo/repo_gin.go
+++ b/internal/route/repo/repo_gin.go
@@ -103,7 +103,8 @@ func readDataciteFile(c *context.Context) {
 // the two variables without modifications.
 // Any errors that occur during processing are stored in the provided context.
 // The FileSize of the annexed content is also saved in the context (c.Data["FileSize"]),
-// along with a flag indicating that the file is annexed (c.Data["IsAnnexedFile"]).
+// along with flags indicating that the file is annexed (c.Data["IsAnnexedFile"]),
+// and that the annexed content is not locally available (c.Data["IsAnnexedContentUnavailable"]).
 func resolveAnnexedContent(c *context.Context, buf []byte) ([]byte, error) {
 	if !tool.IsAnnexedFile(buf) {
 		// not an annex pointer file; return as is
@@ -116,22 +117,23 @@ func resolveAnnexedContent(c *context.Context, buf []byte) ([]byte, error) {
 	key := keyparts[len(keyparts)-1]
 	contentPath, err := git.NewCommand("annex", "contentlocation", key).RunInDir(c.Repo.Repository.RepoPath())
 	if err != nil {
-		log.Error(2, "Failed to find content location for key %q", key)
-		c.Data["IsAnnexedFile"] = true
-		return buf, err
+		log.Warn("Failed to find content location for key %q", key)
+		//key's content is not present in the local repository, meaning that annexed content hasn't been pushed yet
+		c.Data["IsAnnexedContentUnavailable"] = true
+		return buf, nil
 	}
 	// always trim space from output for git command
 	contentPath = bytes.TrimSpace(contentPath)
 	afp, err := os.Open(filepath.Join(c.Repo.Repository.RepoPath(), string(contentPath)))
 	if err != nil {
 		log.Trace("Could not open annex file: %v", err)
-		c.Data["IsAnnexedFile"] = true
+		c.Data["IsAnnexedContentUnavailable"] = true
 		return buf, err
 	}
 	info, err := afp.Stat()
 	if err != nil {
 		log.Trace("Could not stat annex file: %v", err)
-		c.Data["IsAnnexedFile"] = true
+		c.Data["IsAnnexedContentUnavailable"] = true
 		return buf, err
 	}
 	annexDataReader := bufio.NewReader(afp)

--- a/internal/route/repo/view.go
+++ b/internal/route/repo/view.go
@@ -150,6 +150,7 @@ func renderFile(c *context.Context, entry *git.TreeEntry, treeLink, rawLink stri
 	if err != nil {
 		return
 	}
+	isannex := c.Data["IsAnnexedFile"] == true
 	isTextFile := tool.IsTextFile(p)
 	c.Data["IsTextFile"] = isTextFile
 
@@ -232,7 +233,6 @@ func renderFile(c *context.Context, entry *git.TreeEntry, treeLink, rawLink stri
 			c.Data["LineNums"] = gotemplate.HTML(output.String())
 		}
 
-		isannex := tool.IsAnnexedFile(p)
 		if canEnableEditor && !isannex {
 			c.Data["CanEditFile"] = true
 			c.Data["EditFileTooltip"] = c.Tr("repo.editor.edit_this_file")
@@ -251,9 +251,9 @@ func renderFile(c *context.Context, entry *git.TreeEntry, treeLink, rawLink stri
 	case tool.IsImageFile(p) && (c.Data["FileSize"].(int64) < conf.Repository.RawCaptchaMinFileSize*annex.MEGABYTE ||
 		c.IsLogged):
 		c.Data["IsImageFile"] = true
-	case tool.IsAnnexedFile(p) && (c.Data["FileSize"].(int64) < conf.Repository.RawCaptchaMinFileSize*annex.MEGABYTE ||
+	case isannex && (c.Data["FileSize"].(int64) < conf.Repository.RawCaptchaMinFileSize*annex.MEGABYTE ||
 		c.IsLogged):
-		c.Data["IsAnnexedFile"] = true
+		//
 	}
 
 	if canEnableEditor {

--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -142,7 +142,7 @@
 					{{if .IsImageFile}}
 						<img src="{{EscapePound $.RawFileLink}}">
 
-					{{else if .IsAnnexedFile}}
+					{{else if .IsAnnexedContentUnavailable}}
 						<div class="ui yellow segment">
 							<strong>File content is not available</strong>
 							<p>


### PR DESCRIPTION
Fix for issue #134: Restore what seems to be the previous behaviour, namely preventing annexed files to be edited in the WebUI.

Indeed annexed content detection at :
https://github.com/G-Node/gogs/blob/966e925cf320beff768b192276774d9265706df5/internal/route/repo/view.go#L235
would inevitably fail since file content has already been replaced by annexed content at :
https://github.com/G-Node/gogs/blob/966e925cf320beff768b192276774d9265706df5/internal/route/repo/view.go#L149

